### PR TITLE
Adding Time To Control MovieClip Animations

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,6 +30,7 @@ module.exports = function(grunt) {
             '<%= dirs.src %>/utils/EventTarget.js',
             '<%= dirs.src %>/utils/Detector.js',
             '<%= dirs.src %>/utils/Polyk.js',
+            '<%= dirs.src %>/time/Time.js',
             '<%= dirs.src %>/renderers/webgl/WebGLShaders.js',
             '<%= dirs.src %>/renderers/webgl/WebGLGraphics.js',
             '<%= dirs.src %>/renderers/webgl/WebGLRenderer.js',

--- a/src/pixi/display/MovieClip.js
+++ b/src/pixi/display/MovieClip.js
@@ -130,7 +130,7 @@ PIXI.MovieClip.prototype.updateTransform = function()
 	
 	if(!this.playing)return;
 	
-	this.currentFrame += this.animationSpeed * PIXI.Time.timeScale;
+	this.currentFrame += this.animationSpeed * this.stage.time.timeScale;
 	
 	var round = (this.currentFrame + 0.5) | 0;
 	

--- a/src/pixi/display/MovieClip.js
+++ b/src/pixi/display/MovieClip.js
@@ -130,7 +130,7 @@ PIXI.MovieClip.prototype.updateTransform = function()
 	
 	if(!this.playing)return;
 	
-	this.currentFrame += this.animationSpeed;
+	this.currentFrame += this.animationSpeed * PIXI.Time.timeScale;
 	
 	var round = (this.currentFrame + 0.5) | 0;
 	

--- a/src/pixi/display/Stage.js
+++ b/src/pixi/display/Stage.js
@@ -51,6 +51,15 @@ PIXI.Stage = function(backgroundColor, interactive)
 	 */
 	this.dirty = true;
 
+	/**
+	 * time is an instance of the Time class. It can be used to perform frame independent animations.
+	 * This property will be set by the renderer during render.
+	 *
+	 * @property time
+	 * @type {Time}
+	 */	
+	this.time = null;
+
 	this.__childrenAdded = [];
 	this.__childrenRemoved = [];
 

--- a/src/pixi/renderers/canvas/CanvasRenderer.js
+++ b/src/pixi/renderers/canvas/CanvasRenderer.js
@@ -13,6 +13,9 @@
  * @param height=0 {Number} the height of the canvas view
  * @param view {Canvas} the canvas to use as a view, optional
  * @param transparent=false {Boolean} the transparency of the render view, default false
+ * @param targetFrameRate {Number}=60 target framerate for MovieClip animations and other time based animations
+ * @param minFrameRate {Number}=12 minimum framerate update for MovieClips and other time based animations
+ *
  */
 PIXI.CanvasRenderer = function(width, height, view, transparent, targetFrameRate, minFrameRate )
 {

--- a/src/pixi/renderers/canvas/CanvasRenderer.js
+++ b/src/pixi/renderers/canvas/CanvasRenderer.js
@@ -14,7 +14,7 @@
  * @param view {Canvas} the canvas to use as a view, optional
  * @param transparent=false {Boolean} the transparency of the render view, default false
  */
-PIXI.CanvasRenderer = function(width, height, view, transparent)
+PIXI.CanvasRenderer = function(width, height, view, transparent, targetFrameRate, minFrameRate )
 {
 	this.transparent = transparent;
 
@@ -51,6 +51,15 @@ PIXI.CanvasRenderer = function(width, height, view, transparent)
 	 */
 	this.context = this.view.getContext("2d");
 
+	/**
+	 * time is an instance if Time. It will be used to cap the framerate of MovieClip's it can also be used to
+	 * perform framerate independent programmatic animations.
+	 *
+	 * @property time
+	 * @type {Time}
+	 */
+	this.time = new PIXI.Time( targetFrameRate, minFrameRate );
+
 	this.refresh = true;
 	// hack to enable some hardware acceleration!
 	//this.view.style["transform"] = "translatez(0)";
@@ -74,6 +83,8 @@ PIXI.CanvasRenderer.prototype.render = function(stage)
 	
 	//stage.__childrenAdded = [];
 	//stage.__childrenRemoved = [];
+
+	stage.time = this.time;
 	
 	// update textures if need be
 	PIXI.texturesToUpdate = [];
@@ -107,7 +118,7 @@ PIXI.CanvasRenderer.prototype.render = function(stage)
 		PIXI.Texture.frameUpdates = [];
 	}
 	
-	PIXI.Time.update();
+	this.time.update();
 }
 
 /**

--- a/src/pixi/renderers/canvas/CanvasRenderer.js
+++ b/src/pixi/renderers/canvas/CanvasRenderer.js
@@ -107,7 +107,7 @@ PIXI.CanvasRenderer.prototype.render = function(stage)
 		PIXI.Texture.frameUpdates = [];
 	}
 	
-	
+	PIXI.Time.update();
 }
 
 /**

--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -192,6 +192,8 @@ PIXI.WebGLRenderer.prototype.render = function(stage)
 		
 		PIXI.Texture.frameUpdates = [];
 	}
+
+	PIXI.Time.update();
 }
 
 /**

--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -23,7 +23,7 @@ PIXI.gl;
  * @param antialias=false {Boolean} sets antialias (only applicable in chrome at the moment)
  * 
  */
-PIXI.WebGLRenderer = function(width, height, view, transparent, antialias)
+PIXI.WebGLRenderer = function(width, height, view, transparent, antialias, targetFrameRate, minFrameRate )
 {
 	// do a catch.. only 1 webGL renderer..
 
@@ -35,6 +35,15 @@ PIXI.WebGLRenderer = function(width, height, view, transparent, antialias)
 	this.view = view || document.createElement( 'canvas' ); 
     this.view.width = this.width;
 	this.view.height = this.height;
+
+	/**
+	 * time is an instance if Time. It will be used to cap the framerate of MovieClip's it can also be used to
+	 * perform framerate independent programmatic animations.
+	 *
+	 * @property time
+	 * @type {Time}
+	 */
+	this.time = new PIXI.Time( targetFrameRate, minFrameRate );
 
 	// deal with losing context..	
     var scope = this;
@@ -127,7 +136,8 @@ PIXI.WebGLRenderer.returnBatch = function(batch)
 PIXI.WebGLRenderer.prototype.render = function(stage)
 {
 	if(this.contextLost)return;
-	
+
+	stage.time = this.time;
 	
 	// if rendering a new stage clear the batchs..
 	if(this.__stage !== stage)
@@ -193,7 +203,7 @@ PIXI.WebGLRenderer.prototype.render = function(stage)
 		PIXI.Texture.frameUpdates = [];
 	}
 
-	PIXI.Time.update();
+	this.time.update();
 }
 
 /**

--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -21,6 +21,8 @@ PIXI.gl;
  * @param view {Canvas} the canvas to use as a view, optional
  * @param transparent=false {Boolean} the transparency of the render view, default false
  * @param antialias=false {Boolean} sets antialias (only applicable in chrome at the moment)
+ * @param targetFrameRate {Number}=60 target framerate for MovieClip animations and other time based animations
+ * @param minFrameRate {Number}=12 minimum framerate update for MovieClips and other time based animations
  * 
  */
 PIXI.WebGLRenderer = function(width, height, view, transparent, antialias, targetFrameRate, minFrameRate )

--- a/src/pixi/time/Time.js
+++ b/src/pixi/time/Time.js
@@ -2,14 +2,36 @@
  * @author Mikko Haapoja http://mikkoh.com/ @MikkoH
  */
 
+
 /**
-Time is a static class that can be used to ensure that items update independent of framerate. Movieclip's
-framerate will be capped by the timeScale property which is updated during every render call.
+ * The base class for all objects that are rendered on the screen.
+ *
+ * @class DisplayObject
+ * @constructor
+ */
+
+/**
+Time is a class that can be used to ensure that items update independent of framerate. Movieclip's
+framerate will be capped by the timeScale property which is updated during every render call. Each
+renderer will have their own instance of Time which will do the limitting for MovieClips.
 
 @class Time
 @static
 **/
-PIXI.Time = {
+PIXI.Time = function( targetFrameRate, minFrameRate ) {
+
+	if( targetFrameRate !== undefined ) {
+
+		this.setTargetFrameRate( targetFrameRate );
+	}
+
+	if( minFrameRate !== undefined ) {
+
+		this.setMinFrameRate( minFrameRate );
+	}
+};
+
+PIXI.Time.prototype = {
 
 /**
  * is the update scale based on the target framerate. So for example if you're expecting something
@@ -85,7 +107,7 @@ PIXI.Time = {
  * @type Number
  * @default 60
  */
-Object.defineProperty( PIXI.Time, 'targetFrameRate', {
+Object.defineProperty( PIXI.Time.prototype, 'targetFrameRate', {
 
 	get: PIXI.Time.getTargetFrameRate,
 	set: PIXI.Time.setTargetFrameRate
@@ -100,7 +122,7 @@ Object.defineProperty( PIXI.Time, 'targetFrameRate', {
  * @type Number
  * @default 12
  */
-Object.defineProperty( PIXI.Time, 'minFrameRate', {
+Object.defineProperty( PIXI.Time.prototype, 'minFrameRate', {
 
 	get: PIXI.Time.getMinFrameRate,
 	set: PIXI.Time.setMinFrameRate

--- a/src/pixi/time/Time.js
+++ b/src/pixi/time/Time.js
@@ -1,0 +1,107 @@
+/**
+ * @author Mikko Haapoja http://mikkoh.com/ @MikkoH
+ */
+
+/**
+Time is a static class that can be used to ensure that items update independent of framerate. Movieclip's
+framerate will be capped by the timeScale property which is updated during every render call.
+
+@class Time
+@static
+**/
+PIXI.Time = {
+
+/**
+ * is the update scale based on the target framerate. So for example if you're expecting something
+ * doing something like x += 10 per frame at 60fps. You can do this: x += 10 * PIXI.Time.timeScale
+ * to ensure that you're moving at a constant rate regardless of framerate. This property is updated
+ * everytime the render function of the renderers is called.
+ *
+ * @property timeScale
+ * @type Number
+ * @default 1
+ */
+	timeScale: 1,
+
+	_tFrameRate: 60,
+	_minFrameRate: 12,
+	_tMilli: 1000 / 60,
+	_minMilli: 1000 / 12,
+	_prevMilli: Date.now(),
+	
+//This is the setter function for the targetFrameRate
+	setTargetFrameRate: function( framerate ) {
+
+		this._tFrameRate = framerate;
+		this._tMilli = 1000 / framerate;
+	},
+
+//This is the getter function for the targetFrameRate
+	getTargetFrameRate: function() {
+
+		return this._tFrameRate;
+	},
+
+//This is the setter function for the minFrameRate
+	setMinFrameRate: function( framerate ) {
+
+		if( framerate > this._tFrameRate ) {
+
+			throw 'Your target minimum framerate must be smaller than your target framerate: ' + this._tFrameRate;
+		} else {
+
+			this._minFrameRate = framerate;
+			this._minMilli = 1000 / framerate;
+		}
+	},
+
+//This is the getter function for the minFrameRate
+	getMinFrameRate: function() {
+
+		return this._minFrameRate;
+	},
+
+//This is the update function which will get called by the renderers
+	update: function() {
+
+		var curMilli = Date.now();
+		var milliDif = curMilli - this._prevMilli;
+
+		if( milliDif > this._minMilli ) {
+
+			milliDif = this._minMilli;
+		}
+
+		this.timeScale = milliDif / this._tMilli;
+
+		this._prevMilli = curMilli;
+	}
+};
+
+/**
+ * Indicates the target frame rate for all MovieClip animations.
+ *
+ * @property targetFrameRate
+ * @type Number
+ * @default 60
+ */
+Object.defineProperty( PIXI.Time, 'targetFrameRate', {
+
+	get: PIXI.Time.getTargetFrameRate,
+	set: PIXI.Time.setTargetFrameRate
+});
+
+/**
+ * Indicates the minimum frame rate for all MovieClip animations. If for some reason the framerate drops very low
+ * the frame rate of animations will be capped to update at 12 fps. As a note this property is mostly used to
+ * cap the next update if render() has not been called for a long time.
+ *
+ * @property minFrameRate
+ * @type Number
+ * @default 12
+ */
+Object.defineProperty( PIXI.Time, 'minFrameRate', {
+
+	get: PIXI.Time.getMinFrameRate,
+	set: PIXI.Time.setMinFrameRate
+});

--- a/src/pixi/utils/Detector.js
+++ b/src/pixi/utils/Detector.js
@@ -14,10 +14,12 @@
  * @param view {Canvas} the canvas to use as a view, optional
  * @param transparent=false {Boolean} the transparency of the render view, default false
  * @param antialias=false {Boolean} sets antialias (only applicable in webGL chrome at the moment)
+ * @param targetFrameRate {Number}=60 target framerate for MovieClip animations and other time based animations
+ * @param minFrameRate {Number}=12 minimum framerate update for MovieClips and other time based animations
  * 
  * antialias
  */
-PIXI.autoDetectRenderer = function(width, height, view, transparent, antialias)
+PIXI.autoDetectRenderer = function(width, height, view, transparent, antialias, targetFrameRate, minFrameRate )
 {
 	if(!width)width = 800;
 	if(!height)height = 600;
@@ -28,10 +30,10 @@ PIXI.autoDetectRenderer = function(width, height, view, transparent, antialias)
 	//console.log(webgl);
 	if( webgl )
 	{
-		return new PIXI.WebGLRenderer(width, height, view, transparent, antialias);
+		return new PIXI.WebGLRenderer(width, height, view, transparent, antialias, targetFrameRate, minFrameRate );
 	}
 
-	return	new PIXI.CanvasRenderer(width, height, view, transparent);
+	return new PIXI.CanvasRenderer(width, height, view, transparent, targetFrameRate, minFrameRate );
 };
 
 


### PR DESCRIPTION
This pull request is an update to the Pull Request: https://github.com/GoodBoyDigital/pixi.js/pull/322

I've made ```Time``` not be a static object but rather now each renderer will have an instance of time. It is set to a new property on ```Stage``` called time.