### PR TITLE
Added ability to change BitmapText tint and alpha per-character

### DIFF
--- a/src/pixi/text/BitmapText.js
+++ b/src/pixi/text/BitmapText.js
@@ -98,18 +98,18 @@ PIXI.BitmapText.parseColors = function (text)
         {
             // looks like we have a code, so parse as appropriate
             if (currentToken[1] === '')
-            { 
+            {
                 // matches a {#} (revert) code
                 output.push({ tint: -1, alpha: 1 });
             }
             else {
                 if (currentToken[1].length === 6)
-                { 
+                {
                     // matches a {#ffffff} (RGB) code
                     output.push({ tint: parseInt(currentToken[1], 16), alpha: 1 });
                 }
                 else if (currentToken[1].length === 8)
-                { 
+                {
                     // matches a {#ffffffff} (RGBA) code
                     output.push({
                         tint: parseInt(currentToken[1].substr(0, 6), 16),


### PR DESCRIPTION
Added ability to specify tint and alpha per-character on BitmapText through the use of (optional) codes in the format {#ffffff} (RGB), {#ffffffff} (RGBA) and {#} to revert to the default color of the text. If codes are detected then the text is parsed appropriately, otherwise the text behaves as normal.

Example available here: http://rotates.org/phaser/bitmaptextcolor.htm

Parsing could be more efficient, however the above example shows that even with relatively frequent updates it appears to perform well, even using canvas on mobile.