### PR TITLE
A little patch to CanvasTinter.js to fix a performance issue (ipad/ipad mini crash)

### DIFF
--- a/src/pixi/renderers/canvas/utils/CanvasTinter.js
+++ b/src/pixi/renderers/canvas/utils/CanvasTinter.js
@@ -48,7 +48,7 @@ PIXI.CanvasTinter.getTintedTexture = function(sprite, color)
     PIXI.CanvasTinter.tintMethod(texture, color, canvas);
 
 	//preserve this canvas to use it for next time we need to re-tint the texture.
-	texture.tintCache.canvas = canvas;	
+	texture.tintCache.canvas = canvas;
 
     if(PIXI.CanvasTinter.convertTintToImage)
     {

--- a/src/pixi/renderers/canvas/utils/CanvasTinter.js
+++ b/src/pixi/renderers/canvas/utils/CanvasTinter.js
@@ -40,12 +40,15 @@ PIXI.CanvasTinter.getTintedTexture = function(sprite, color)
     if(texture.tintCache[stringColor]) return texture.tintCache[stringColor];
 
      // clone texture..
-    var canvas = PIXI.CanvasTinter.canvas || document.createElement("canvas");
+    var canvas = texture.tintCache['canvas'] || PIXI.CanvasTinter.canvas || document.createElement("canvas");
     
     //PIXI.CanvasTinter.tintWithPerPixel(texture, stringColor, canvas);
 
     
     PIXI.CanvasTinter.tintMethod(texture, color, canvas);
+
+	//preserve this canvas to use it for next time we need to re-tint the texture.
+	texture.tintCache['canvas'] = canvas;	
 
     if(PIXI.CanvasTinter.convertTintToImage)
     {

--- a/src/pixi/renderers/canvas/utils/CanvasTinter.js
+++ b/src/pixi/renderers/canvas/utils/CanvasTinter.js
@@ -40,7 +40,7 @@ PIXI.CanvasTinter.getTintedTexture = function(sprite, color)
     if(texture.tintCache[stringColor]) return texture.tintCache[stringColor];
 
      // clone texture..
-    var canvas = texture.tintCache['canvas'] || PIXI.CanvasTinter.canvas || document.createElement("canvas");
+    var canvas = texture.tintCache.canvas || PIXI.CanvasTinter.canvas || document.createElement("canvas");
     
     //PIXI.CanvasTinter.tintWithPerPixel(texture, stringColor, canvas);
 
@@ -48,7 +48,7 @@ PIXI.CanvasTinter.getTintedTexture = function(sprite, color)
     PIXI.CanvasTinter.tintMethod(texture, color, canvas);
 
 	//preserve this canvas to use it for next time we need to re-tint the texture.
-	texture.tintCache['canvas'] = canvas;	
+	texture.tintCache.canvas = canvas;	
 
     if(PIXI.CanvasTinter.convertTintToImage)
     {


### PR DESCRIPTION
the situation : when you handle a lot of textures with tints changing overthe time, the performance drop.
I noticed that document.createElement("canvas") is done for each new tint.
this patch only save the initially created canvas so it'll be used for all future texture tinting.

on ipad/ipad mini I had crashes without the patch and 10~30 FPS ... with the patch I get 55~60 FPS and no more crash :)