### PR TITLE
Safari Pixel Rounding Fix

### DIFF
--- a/src/pixi/display/Sprite.js
+++ b/src/pixi/display/Sprite.js
@@ -326,6 +326,10 @@ PIXI.Sprite.prototype._renderCanvas = function(renderSession)
     {
         renderSession.context.globalAlpha = this.worldAlpha;
 
+        //  If the texture is trimmed we offset by the trim x/y, otherwise we use the frame dimensions
+        var dx = (this.texture.trim) ? this.texture.trim.x - this.anchor.x * this.texture.trim.width : this.anchor.x * -this.texture.frame.width;
+        var dy = (this.texture.trim) ? this.texture.trim.y - this.anchor.y * this.texture.trim.height : this.anchor.y * -this.texture.frame.height;
+
         //  Allow for pixel rounding
         if (renderSession.roundPixels)
         {
@@ -336,6 +340,8 @@ PIXI.Sprite.prototype._renderCanvas = function(renderSession)
                 this.worldTransform.d,
                 this.worldTransform.tx | 0,
                 this.worldTransform.ty | 0);
+            dx = dx | 0;
+            dy = dy | 0;
         }
         else
         {
@@ -354,10 +360,6 @@ PIXI.Sprite.prototype._renderCanvas = function(renderSession)
             renderSession.scaleMode = this.texture.baseTexture.scaleMode;
             renderSession.context[renderSession.smoothProperty] = (renderSession.scaleMode === PIXI.scaleModes.LINEAR);
         }
-
-        //  If the texture is trimmed we offset by the trim x/y, otherwise we use the frame dimensions
-        var dx = (this.texture.trim) ? this.texture.trim.x - this.anchor.x * this.texture.trim.width : this.anchor.x * -this.texture.frame.width;
-        var dy = (this.texture.trim) ? this.texture.trim.y - this.anchor.y * this.texture.trim.height : this.anchor.y * -this.texture.frame.height;
 
         if (this.tint !== 0xFFFFFF)
         {


### PR DESCRIPTION
Safari automatically anti-aliases when not drawing to the canvas with pixel-perfect (integer) coordinates. I imagine this should be fixed by setting the CanvasRenderer.renderSession.roundPixels = true, but this can result in weird behavior if a Sprite frame offset is not an integer (eg. x-anchor at .5 on a 15-pixel wide sprite results in a dx of -7.5).

This might not be the best way to fix this, but I'm just truncating the decimal from the dx and dy frame offsets. It seems to work for me.

Before: http://jsfiddle.net/jiminychris/z3srL5dy/

After: http://jsfiddle.net/jiminychris/mygLLr9c/

Note that these should look exactly the same in Chrome, and this was only an issue in Safari, as far as I can tell.