### PR TITLE
Optimalization of updateTransform in Spine, condition has been met every time, attachment.name does not exist

### DIFF
--- a/src/pixi/extras/Spine.js
+++ b/src/pixi/extras/Spine.js
@@ -1426,7 +1426,7 @@ PIXI.Spine.prototype.updateTransform = function () {
         }
 
         if (attachment.rendererObject) {
-            if (!slot.currentSpriteName || slot.currentSpriteName != attachment.name) {
+            if (!slot.currentSpriteName || slot.currentSpriteName != attachment.rendererObject.name) {
                 var spriteName = attachment.rendererObject.name;
                 if (slot.currentSprite !== undefined) {
                     slot.currentSprite.visible = false;


### PR DESCRIPTION
Condition with attachment.name changed to attachment.rendererObject.name, because attachment.name never exists