### PR TITLE
[FILTERS] Renderbuffers should always be reseted after use.

### DIFF
--- a/src/pixi/renderers/webgl/utils/FilterTexture.js
+++ b/src/pixi/renderers/webgl/utils/FilterTexture.js
@@ -40,6 +40,7 @@ PIXI.FilterTexture = function(gl, width, height, scaleMode)
     this.renderBuffer = gl.createRenderbuffer();
     gl.bindRenderbuffer(gl.RENDERBUFFER, this.renderBuffer);
     gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, this.renderBuffer);
+	gl.bindRenderbuffer(gl.RENDERBUFFER, null);
   
     this.resize(width, height);
 };
@@ -79,6 +80,7 @@ PIXI.FilterTexture.prototype.resize = function(width, height)
     // update the stencil buffer width and height
     gl.bindRenderbuffer(gl.RENDERBUFFER, this.renderBuffer);
     gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, width , height );
+	gl.bindRenderbuffer(gl.RENDERBUFFER, null);
 };
 
 /**


### PR DESCRIPTION
Fixes filter rendering issue in Ejecta. Filters would lose the render targets and the screen would freeze.