### PR TITLE
Adds 2 new properties to DisplayObject: scaleMin and scaleMax.

### DIFF
--- a/src/pixi/display/DisplayObject.js
+++ b/src/pixi/display/DisplayObject.js
@@ -28,6 +28,24 @@ PIXI.DisplayObject = function()
     this.scale = new PIXI.Point(1,1);//{x:1, y:1};
 
     /**
+     * Set the minimum scale this Display Object will scale down to.
+     * Prevents a parent from scaling this Display Object lower than the given value. Set to `null` to remove.
+     * 
+     * @property scaleMin
+     * @type Point
+     */
+    this.scaleMin = null;
+
+    /**
+     * Set the maximum scale this Display Object will scale up to.
+     * Prevents a parent from scaling this Display Object higher than the given value. Set to `null` to remove.
+     * 
+     * @property scaleMax
+     * @type Point
+     */
+    this.scaleMax = null;
+
+    /**
      * The pivot point of the displayObject that it rotates around
      *
      * @property pivot
@@ -512,8 +530,105 @@ PIXI.DisplayObject.prototype.updateTransform = function()
         wt.ty = tx * pt.b + ty * pt.d + pt.ty;
     }
 
+    if (this.scaleMin)
+    {
+        if (wt.a < this.scaleMin.x)
+        {
+            wt.a = this.scaleMin.x;
+        }
+
+        if (wt.d < this.scaleMin.y)
+        {
+            wt.d = this.scaleMin.y;
+        }
+    }
+
+    if (this.scaleMax)
+    {
+        if (wt.a > this.scaleMax.x)
+        {
+            wt.a = this.scaleMax.x;
+        }
+
+        if (wt.d > this.scaleMax.y)
+        {
+            wt.d = this.scaleMax.y;
+        }
+    }
+
     // multiply the alphas..
     this.worldAlpha = this.alpha * this.parent.worldAlpha;
+};
+
+/**
+ * Sets the scaleMin and scaleMax values in one call.
+ * 
+ * These values are used to limit how far this Display Object will scale (either up or down) based on its parent.
+ * For example if this Display Object has a minScale value of 1 and its parent has a scale value of 0.5, the 0.5 will be ignored and the scale value of 1 will be used.
+ * By setting these values you can carefully control how Display Objects deal with responsive scaling.
+ * 
+ * If only one parameter is given then that value will be used for both scaleMin and scaleMax:
+ * setScaleMinMax(1) = scaleMin.x, scaleMin.y, scaleMax.x and scaleMax.y all = 1
+ *
+ * If only two parameters are given the first is set as scaleMin.x and y and the second as scaleMax.x and y:
+ * setScaleMinMax(0.5, 2) = scaleMin.x and y = 0.5 and scaleMax.x and y = 2
+ *
+ * If you wish to set scaleMin with different values for x and y then either set DisplayObject.scaleMin directly, or pass `null` for the maxX and maxY parameters.
+ * 
+ * Call setScaleMinMax(null) to clear both the scaleMin and scaleMax values.
+ *
+ * @method setScaleMinMax
+ * @param minX {number|null} The minimum horizontal scale value this Display Object can scale down to.
+ * @param minY {number|null} The minimum vertical scale value this Display Object can scale down to.
+ * @param maxX {number|null} The maximum horizontal scale value this Display Object can scale up to.
+ * @param maxY {number|null} The maximum vertical scale value this Display Object can scale up to.
+ */
+PIXI.DisplayObject.prototype.setScaleMinMax = function (minX, minY, maxX, maxY) {
+
+    if (typeof minY === 'undefined')
+    {
+        //  1 parameter, set all to it
+        minY = maxX = maxY = minX;
+    }
+    else if (typeof maxX === 'undefined')
+    {
+        //  2 parameters, the first is min, the second max
+        maxX = maxY = minY;
+        minY = minX;
+    }
+
+    if (minX === null)
+    {
+        this.scaleMin = null;
+    }
+    else
+    {
+        if (this.scaleMin)
+        {
+            this.scaleMin.set(minX, minY);
+        }
+        else
+        {
+            this.scaleMin = new Phaser.Point(minX, minY);
+        }
+    }
+
+    if (maxX === null)
+    {
+        this.scaleMax = null;
+    }
+    else
+    {
+        if (this.scaleMax)
+        {
+            this.scaleMax.set(maxX, maxY);
+        }
+        else
+        {
+            this.scaleMax = new Phaser.Point(maxX, maxY);
+        }
+    }
+
 };
 
 /**

--- a/src/pixi/display/DisplayObject.js
+++ b/src/pixi/display/DisplayObject.js
@@ -609,7 +609,7 @@ PIXI.DisplayObject.prototype.setScaleMinMax = function (minX, minY, maxX, maxY) 
         }
         else
         {
-            this.scaleMin = new Phaser.Point(minX, minY);
+            this.scaleMin = new PIXI.Point(minX, minY);
         }
     }
 
@@ -625,7 +625,7 @@ PIXI.DisplayObject.prototype.setScaleMinMax = function (minX, minY, maxX, maxY) 
         }
         else
         {
-            this.scaleMax = new Phaser.Point(maxX, maxY);
+            this.scaleMax = new PIXI.Point(maxX, maxY);
         }
     }
 


### PR DESCRIPTION
These are Point objects that allow you to set a lower and upper bounds on the scale value the display object can transform to. The updateTransform method now checks these two properties (if set) and enforces them.

A small helper method setScaleMinMax has been added to allow the devs to quickly set these two properties, but if you feel it's not needed then you can remove it and it'll carry on working happily with it out.

I have found these 2 properties utterly invaluable in some responsive bbc games we've been building. For example we had a case where the whole game scaled responsively, but the top-level UI was never allowed to go below a certain size (or it becamse impossible to touch). Setting just the scaleMin allowed this, but it could still scale up happily on larger displays.