### PR TITLE
Allow filter areas to originate off screen. Clip filter areas to on screen portion.

### DIFF
--- a/src/pixi/renderers/webgl/utils/WebGLFilterManager.js
+++ b/src/pixi/renderers/webgl/utils/WebGLFilterManager.js
@@ -104,10 +104,31 @@ PIXI.WebGLFilterManager.prototype.pushFilter = function(filterBlock)
     filterArea.height += padding * 2;
 
     // cap filter to screen size..
-    if(filterArea.x < 0)filterArea.x = 0;
-    if(filterArea.width > this.width)filterArea.width = this.width;
-    if(filterArea.y < 0)filterArea.y = 0;
-    if(filterArea.height > this.height)filterArea.height = this.height;
+    var localX = filterArea.x;
+    var localY = filterArea.y;
+
+    if (filterArea.x < 0)
+    {
+        filterArea.width += filterArea.x;
+        filterArea.x = 0;
+    }
+    if (filterArea.y < 0)
+    {
+        filterArea.height += filterArea.y;
+        filterArea.y = 0;
+    }
+
+    if (localX + filterArea.width > this.width)
+    {
+        filterArea.width = this.width - localX;
+    }
+    if (localY + filterArea.height > this.height)
+    {
+        filterArea.height = this.height - localY;
+    }
+    
+    if (filterArea.width < 0) filterArea.width = 0;
+    if (filterArea.height < 0) filterArea.height = 0;
 
     //gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA,  filterArea.width, filterArea.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
     gl.bindFramebuffer(gl.FRAMEBUFFER, texture.frameBuffer);


### PR DESCRIPTION
Clamping filter area origin to 0 means filters cant go partially off screen due to camera scrolling etc, but stick to the edge in full size.

This guy had the same problem http://www.html5gamedevs.com/topic/9638-webgl-filters-rendering-offset/

This commit should clip the filter area to the visible part of the screen, but an alternative fix might be just removing the 4 lines here https://github.com/GoodBoyDigital/pixi.js/blob/master/src/pixi/renderers/webgl/utils/WebGLFilterManager.js#L106-110