### PR TITLE
BaseTexture updates and timing fixes

### DIFF
--- a/src/pixi/textures/BaseTexture.js
+++ b/src/pixi/textures/BaseTexture.js
@@ -196,7 +196,7 @@ PIXI.BaseTexture.prototype.loadSource = function(source)
         this.height = source.naturalHeight || source.height;
         this.dirty();
     }
-    else if('onload' in source)
+    else if(!source.getContext)
     {
         // Image fail / not ready
         this.isLoading = true;


### PR DESCRIPTION
Addresses the issue in https://github.com/GoodBoyDigital/pixi.js/pull/1165 but does not delay the `src` assignment and thus the immediately-ready path is still available. Also addresses a few other edge cases and adds/updates relevant documentation.

---

- Fixes obscure image-load timing issues. This can be caused because
  `Image.complete` is not synchronouse with respect to script execution.
  - http://www.w3.org/TR/html5/embedded-content-0.html#the-img-element
  - https://github.com/GoodBoyDigital/pixi.js/pull/1165

- Fixed `updateSourceImage` so it will correctly run through the loading
  process again, as if specified as the original source.

- DOM events are removed once they are done being useful.

- Added `isLoading` so that a non-async never-going-to-load can be
  detected.

- Updated documentation to account for accepting a Canvas and the default
  values applied, the behavior of `loadSource` and the 'loaded' and
  'error' events.