### PR TITLE
Add 'pixelRatio' property

### DIFF
--- a/src/pixi/InteractionManager.js
+++ b/src/pixi/InteractionManager.js
@@ -30,6 +30,14 @@ PIXI.InteractionManager = function(stage)
     this.mouse = new PIXI.InteractionData();
 
     /**
+     * The touch data
+     *
+     * @property touchData
+     * @type InteractionData
+     */
+    this.touchData = null;
+
+    /**
      * An object that stores current touches (InteractionData) by id reference
      *
      * @property touches
@@ -223,7 +231,7 @@ PIXI.InteractionManager.prototype.setTarget = function(target)
 PIXI.InteractionManager.prototype.setPixelRatio = function(value)
 {
     this.pixelRatio = value;
-    this.resolution /= this.pixelRatio;
+    this.resolution = this.resolution / this.pixelRatio;
 };
 
 /**
@@ -714,23 +722,23 @@ PIXI.InteractionManager.prototype.onTouchMove = function(event)
 
     var rect = this.interactionDOMElement.getBoundingClientRect();
     var changedTouches = event.changedTouches;
-    var touchData;
+    //var touchData;
     var i = 0;
 
     for (i = 0; i < changedTouches.length; i++)
     {
         var touchEvent = changedTouches[i];
-        touchData = this.touches[touchEvent.identifier];
-        touchData.originalEvent = event;
+        this.touchData = this.touches[touchEvent.identifier];
+        this.touchData.originalEvent = event;
 
         // update the touch position
-        touchData.global.x = ( (touchEvent.clientX - rect.left) * (this.target.width / rect.width) ) / this.resolution;
-        touchData.global.y = ( (touchEvent.clientY - rect.top)  * (this.target.height / rect.height) )  / this.resolution;
+        this.touchData.global.x = ( (touchEvent.clientX - rect.left) * (this.target.width / rect.width) ) / this.resolution;
+        this.touchData.global.y = ( (touchEvent.clientY - rect.top)  * (this.target.height / rect.height) )  / this.resolution;
         if (navigator.isCocoonJS && !rect.left && !rect.top && !event.target.style.width && !event.target.style.height)
         {
             //Support for CocoonJS fullscreen scale modes
-            touchData.global.x = touchEvent.clientX;
-            touchData.global.y = touchEvent.clientY;
+            this.touchData.global.x = touchEvent.clientX;
+            this.touchData.global.y = touchEvent.clientY;
         }
 
         for (var j = 0; j < this.interactiveItems.length; j++)
@@ -738,7 +746,7 @@ PIXI.InteractionManager.prototype.onTouchMove = function(event)
             var item = this.interactiveItems[j];
             if (item.touchmove && item.__touchData && item.__touchData[touchEvent.identifier])
             {
-                item.touchmove(touchData);
+                item.touchmove(this.touchData);
             }
         }
     }

--- a/src/pixi/InteractionManager.js
+++ b/src/pixi/InteractionManager.js
@@ -144,6 +144,12 @@ PIXI.InteractionManager = function(stage)
      * @type Number
      */
     this.resolution = 1;
+
+    /**
+     * @property pixelRatio
+     * @type Number
+     */
+    this.pixelRatio = 1;
 };
 
 // constructor
@@ -200,12 +206,24 @@ PIXI.InteractionManager.prototype.collectInteractiveSprite = function(displayObj
 PIXI.InteractionManager.prototype.setTarget = function(target)
 {
     this.target = target;
-    this.resolution = target.resolution;
+    this.resolution = target.resolution / this.pixelRatio;
 
     // Check if the dom element has been set. If it has don't do anything.
     if (this.interactionDOMElement !== null) return;
 
     this.setTargetDomElement (target.view);
+};
+
+/**
+ * Set pixel ratio
+ *
+ * @method setPixelRatio
+ * @param value {number}
+ */
+PIXI.InteractionManager.prototype.setPixelRatio = function(value)
+{
+    this.pixelRatio = value;
+    this.resolution /= this.pixelRatio;
 };
 
 /**

--- a/src/pixi/display/DisplayObjectContainer.js
+++ b/src/pixi/display/DisplayObjectContainer.js
@@ -208,6 +208,18 @@ PIXI.DisplayObjectContainer.prototype.getChildAt = function(index)
 };
 
 /**
+ * Check if the container contains the child passed in
+ *
+ * @method contains
+ * @param {DisplayObject} child
+ * @returns {boolean}
+ */
+PIXI.DisplayObjectContainer.prototype.contains = function(child)
+{
+    return this.children.indexOf(child) > -1;
+};
+
+/**
  * Removes a child from the container.
  *
  * @method removeChild

--- a/src/pixi/display/Stage.js
+++ b/src/pixi/display/Stage.js
@@ -133,3 +133,14 @@ PIXI.Stage.prototype.getMousePosition = function()
 {
     return this.interactionManager.mouse.global;
 };
+
+/**
+ * This will return the point containing global coordinates of the touch.
+ *
+ * @method getTouchPosition
+ * @return {Point} A point containing the coordinates of the global InteractionData position.
+ */
+PIXI.Stage.prototype.getTouchPosition = function()
+{
+    return this.interactionManager.touchData ? this.interactionManager.touchData.global : this.interactionManager.mouse.global;
+};


### PR DESCRIPTION
Using text on Retina displays (or displays with 'devicePixelRatio' > 1) results in blurred text. Also blurred images. I understand that the new 'resolution' property should solve this issue, but I can't get as sharp text/images when set the resolution via PIXI's renderer options. When I scale the canvas manually  (i.e. canvas.style.width = w; canvas.width = w * devicePixelRatio;) I get much sharper text and images, even though the final canvas' HTML element has same dimensions as if using PIXI's resolution. I can't figure the reason why. 

So I introduced property 'pixelRatio' for correct pointers coordinates when the resolution is set to 1, but the canvas is scaled manually outside of PIXI.