### PR TITLE
Change the way array is cleared to zero elements

### DIFF
--- a/src/pixi/InteractionManager.js
+++ b/src/pixi/InteractionManager.js
@@ -369,7 +369,7 @@ PIXI.InteractionManager.prototype.rebuildInteractiveGraph = function()
         this.interactiveItems[i].interactiveChildren = false;
     }
 
-    this.interactiveItems = [];
+    this.interactiveItems.length = 0;
 
     if (this.stage.interactive)
     {


### PR DESCRIPTION
interactiveItems now is cleared by length = 0; instead of creating new array every time =[]; It is more efficient for garbage collector.