### PR TITLE
Also log the type for non-Chrome browsers

### DIFF
--- a/src/pixi/Pixi.js
+++ b/src/pixi/Pixi.js
@@ -206,7 +206,7 @@ PIXI.sayHello = function (type)
     }
     else if (window['console'])
     {
-        console.log('Pixi.js ' + PIXI.VERSION + ' - http://www.pixijs.com/');
+        console.log('Pixi.js ' + PIXI.VERSION + ' - ' + type + ' - http://www.pixijs.com/');
     }
 
     PIXI.dontSayHello = true;


### PR DESCRIPTION
The initial "sayHello" log is not consistent across browsers. There is no way to get the WebGL/Canvas information from the console of Firefox for instance (only works on Chrome).