### PR TITLE
Prefer to expose the unminified version to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "url": "https://github.com/GoodBoyDigital/pixi.js.git"
     },
 
-    "main": "bin/pixi.js",
+    "main": "bin/pixi.dev.js",
 
     "scripts": {
         "test": "grunt travis --verbose"


### PR DESCRIPTION
this is to improve the dev experience when working with PIXI using browserify.
(and up to the final user to minify the resulting build as it is the convention in NPM in general)