### PR TITLE
Allow canvas graphics renderer to process multiple paths per mask

### DIFF
--- a/src/pixi/renderers/canvas/CanvasGraphics.js
+++ b/src/pixi/renderers/canvas/CanvasGraphics.js
@@ -212,20 +212,15 @@ PIXI.CanvasGraphics.renderGraphicsMask = function(graphics, context)
 
     if(len === 0) return;
 
-    if(len > 1)
-    {
-        len = 1;
-        window.console.log('Pixi.js warning: masks in canvas can only mask using the first path in the graphics object');
-    }
+    context.beginPath();
 
-    for (var i = 0; i < 1; i++)
+    for (var i = 0; i < len; i++)
     {
         var data = graphics.graphicsData[i];
         var shape = data.shape;
 
         if(data.type === PIXI.Graphics.POLY)
         {
-            context.beginPath();
         
             var points = shape.points;
         
@@ -245,14 +240,12 @@ PIXI.CanvasGraphics.renderGraphicsMask = function(graphics, context)
         }
         else if(data.type === PIXI.Graphics.RECT)
         {
-            context.beginPath();
             context.rect(shape.x, shape.y, shape.width, shape.height);
             context.closePath();
         }
         else if(data.type === PIXI.Graphics.CIRC)
         {
             // TODO - need to be Undefined!
-            context.beginPath();
             context.arc(shape.x, shape.y, shape.radius,0,2*Math.PI);
             context.closePath();
         }
@@ -267,7 +260,6 @@ PIXI.CanvasGraphics.renderGraphicsMask = function(graphics, context)
             var x = shape.x - w/2;
             var y = shape.y - h/2;
 
-            context.beginPath();
 
             var kappa = 0.5522848,
                 ox = (w / 2) * kappa, // control point offset horizontal
@@ -297,7 +289,6 @@ PIXI.CanvasGraphics.renderGraphicsMask = function(graphics, context)
             var maxRadius = Math.min(width, height) / 2 | 0;
             radius = radius > maxRadius ? maxRadius : radius;
 
-            context.beginPath();
             context.moveTo(rx, ry + radius);
             context.lineTo(rx, ry + height - radius);
             context.quadraticCurveTo(rx, ry + height, rx + radius, ry + height);


### PR DESCRIPTION
I was recently in need of using multiple mask paths to dynamically mask multiple areas of a sprite. This works fine on the WebGL renderer, but the canvas renderer could only handle one mask path per graphics object. Judging by the pre existing for loop, it seems like it may have been originally intended that the canvas renderer be able to mask multiple paths.

I added a single .beginPath() call just before the execution of the for loop. All other .beginPath() calls were removed. I made sure to leave the calls to .closePath(). Since properties such as fillStyle and lineWidth aren't taken into account by canvas clipping, only one call to .beginPath() is needed. This way the canvas can clip using multiple paths.