### PR TITLE
Check if tint is in acceptable range, otherwise set a default value.

### DIFF
--- a/src/pixi/text/BitmapText.js
+++ b/src/pixi/text/BitmapText.js
@@ -166,7 +166,7 @@ PIXI.BitmapText.prototype.updateText = function()
 
     var lenChildren = this.children.length;
     var lenChars = chars.length;
-    var tint = this.tint || 0xFFFFFF;
+    var tint = (typeof this.tint === 'number' && this.tint >= 0) ? this.tint : 0xFFFFFF;
 
     for(i = 0; i < lenChars; i++)
     {


### PR DESCRIPTION
From issue #1305, if you set the tint to black (`0x000000`) it'll fail the first test, even though it's a valid color.