### PR TITLE
Improve BitmapText.setStyle() and add BitmapText.tint attribute.

### DIFF
--- a/src/pixi/text/BitmapText.js
+++ b/src/pixi/text/BitmapText.js
@@ -50,7 +50,7 @@ PIXI.BitmapText = function(text, style)
     /**
      * @property style
      * @type Object
-     * @private
+     * @readOnly
      */
     this.style = {};
 
@@ -69,6 +69,22 @@ PIXI.BitmapText = function(text, style)
 // constructor
 PIXI.BitmapText.prototype = Object.create(PIXI.DisplayObjectContainer.prototype);
 PIXI.BitmapText.prototype.constructor = PIXI.BitmapText;
+
+/**
+ * The tint of the BitmapText object
+ *
+ * @property tint
+ * @type Number
+ */
+Object.defineProperty(PIXI.BitmapText.prototype, 'tint', {
+    get: function() {
+        return this._tint;
+    },
+    set: function(value) {
+        this._tint = value;
+        this.dirty = true;
+    }
+});
 
 /**
  * Set the text string to be rendered.
@@ -97,22 +113,12 @@ PIXI.BitmapText.prototype.setStyle = function(style)
     style.align = style.align || this.style.align || 'left';
     style.font = style.font || this.style.font;
 
-    if(typeof style.tint === 'number') {
-        style.tint = style.tint;
-    } else if(typeof this.style.tint === 'number') {
-        style.tint = this.style.tint;
-    } else {
-        style.tint = 0xFFFFFF;
-    }
-
     // Store the updated style definition
     this.style = style;
 
     var font = style.font.split(' ');
     this.fontName = font[font.length - 1];
     this.fontSize = font.length >= 2 ? parseInt(font[font.length - 2], 10) : PIXI.BitmapText.fonts[this.fontName].size;
-
-    this.tint = style.tint;
 
     this.dirty = true;
 };

--- a/src/pixi/text/BitmapText.js
+++ b/src/pixi/text/BitmapText.js
@@ -47,6 +47,13 @@ PIXI.BitmapText = function(text, style)
      */
     this._pool = [];
 
+    /**
+     * @property style
+     * @type Object
+     * @private
+     */
+    this.style = {};
+
     this.setText(text);
     this.setStyle(style);
     this.updateText();
@@ -85,16 +92,29 @@ PIXI.BitmapText.prototype.setText = function(text)
  */
 PIXI.BitmapText.prototype.setStyle = function(style)
 {
-    style = style || {};
-    style.align = style.align || 'left';
+    if(!style || typeof style !== 'object') return;
+
+    style.align = style.align || this.style.align || 'left';
+    style.font = style.font || this.style.font;
+
+    if(typeof style.tint === 'number') {
+        style.tint = style.tint;
+    } else if(typeof this.style.tint === 'number') {
+        style.tint = this.style.tint;
+    } else {
+        style.tint = 0xFFFFFF;
+    }
+
+    // Store the updated style definition
     this.style = style;
 
     var font = style.font.split(' ');
     this.fontName = font[font.length - 1];
     this.fontSize = font.length >= 2 ? parseInt(font[font.length - 2], 10) : PIXI.BitmapText.fonts[this.fontName].size;
 
-    this.dirty = true;
     this.tint = style.tint;
+
+    this.dirty = true;
 };
 
 /**


### PR DESCRIPTION
`BitmapText.setStyle()` should handle not having every value be defined, and not overwrite existing values with defaults. This is done by checking the input to the function.

`BitmapText.tint` is added, and the behavior is modeled from `Sprite.tint`.

From issue #1305, previous bad PR #1315 