### PR TITLE
Fixed transform order in TilingSprite.

### DIFF
--- a/src/pixi/extras/TilingSprite.js
+++ b/src/pixi/extras/TilingSprite.js
@@ -262,8 +262,8 @@ PIXI.TilingSprite.prototype._renderCanvas = function(renderSession)
                     this._width / tileScale.x,
                     this._height / tileScale.y);
 
-    context.scale(1 / tileScale.x, 1 / tileScale.y);
     context.translate(-tilePosition.x + (this.anchor.x * this._width), -tilePosition.y + (this.anchor.y * this._height));
+    context.scale(1 / tileScale.x, 1 / tileScale.y);
 
     if (this._mask)
     {


### PR DESCRIPTION
When tileScale was non 1 several tilingsprites would affect each other transforms.