### PR TITLE
fix example script path

### DIFF
--- a/examples/example 2 - SpriteSheet/indexTrim.html
+++ b/examples/example 2 - SpriteSheet/indexTrim.html
@@ -9,7 +9,7 @@
             background-color: #000000;
         }
     </style>
-    <script src="../../../bin/pixi.dev.js"></script>
+    <script src="../../bin/pixi.dev.js"></script>
 </head>
 <body>
     <script>


### PR DESCRIPTION
Don't know if you want a PR for this (feel free to close it if not relevant) - but the include path for `pixi.dev.js` is incorrect (so the example doesn't work). It's pointing one level too high.