### PR TITLE
Change to black as default renderer color.

### DIFF
--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -76,7 +76,7 @@ function WebGLRenderer(width, height, options)
      * @member {number}
      * @private
      */
-    this._backgroundColor = 0xFFFFFF;
+    this._backgroundColor = 0x000000;
 
     /**
      * The background color as an [R, G, B] array.


### PR DESCRIPTION
The behavior is different between Canvas and WebGL renderers. I found more instances of black as default color, so I opted to go for that.

#1325 