### PR TITLE
fix mask for CanvasGraphics

### DIFF
--- a/bin/pixi.dev.js
+++ b/bin/pixi.dev.js
@@ -11419,12 +11419,12 @@ PIXI.CanvasGraphics.renderGraphicsMask = function(graphics, context)
         else if (data.type === PIXI.Graphics.RREC)
         {
         
-            var pts = shape.points;
-            var rx = pts[0];
-            var ry = pts[1];
-            var width = pts[2];
-            var height = pts[3];
-            var radius = pts[4];
+            var pts = shape;
+            var rx = pts.x;
+            var ry = pts.y;
+            var width = pts.width;
+            var height = pts.height;
+            var radius = pts.radius;
 
             var maxRadius = Math.min(width, height) / 2 | 0;
             radius = radius > maxRadius ? maxRadius : radius;


### PR DESCRIPTION
I found bug with mask in current (2.2.3) version of PIXI. Just FYI.

Best regards,
Nickolay