### PR TITLE
Added support to different retina prefixes (not only @2x)

### DIFF
--- a/src/pixi/Pixi.js
+++ b/src/pixi/Pixi.js
@@ -143,12 +143,11 @@ PIXI.RAD_TO_DEG = 180 / Math.PI;
 PIXI.DEG_TO_RAD = Math.PI / 180;
 
 /**
- * @property {String} RETINA_PREFIX
+ * @property {RegExp} RETINA_PREFIX
  * @protected
  * @static
  */
-PIXI.RETINA_PREFIX = "@2x";
-//PIXI.SCALE_PREFIX "@x%%";
+PIXI.RETINA_PREFIX = /@(.+)x/;
 
 /**
  * If true the default pixi startup (console) banner message will be suppressed.

--- a/src/pixi/textures/BaseTexture.js
+++ b/src/pixi/textures/BaseTexture.js
@@ -269,7 +269,7 @@ PIXI.BaseTexture.fromImage = function(imageUrl, crossorigin, scaleMode)
 
         var resolution = PIXI.RETINA_PREFIX.exec(imageUrl);
         if (resolution) {
-            baseTexture.resolution = resolution ? parseFloat(resolution[1]) : 1;
+            baseTexture.resolution = parseFloat(resolution[1]);
         }
     }
 

--- a/src/pixi/textures/BaseTexture.js
+++ b/src/pixi/textures/BaseTexture.js
@@ -267,10 +267,9 @@ PIXI.BaseTexture.fromImage = function(imageUrl, crossorigin, scaleMode)
         baseTexture.imageUrl = imageUrl;
         PIXI.BaseTextureCache[imageUrl] = baseTexture;
 
-        // if there is an @2x at the end of the url we are going to assume its a highres image
-        if( imageUrl.indexOf(PIXI.RETINA_PREFIX + '.') !== -1)
-        {
-            baseTexture.resolution = 2;
+        var resolution = PIXI.RETINA_PREFIX.exec(imageUrl);
+        if (resolution) {
+            baseTexture.resolution = resolution ? parseFloat(resolution[1]) : 1;
         }
     }
 


### PR DESCRIPTION
You may want to use different resolutions then @2x - for example I use @0.5x to use low quality textures for low-end devices.