### PR TITLE
Add resolution property to WebGLFilterManager

### DIFF
--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -192,7 +192,7 @@ PIXI.WebGLRenderer = function(width, height, options)
      * @property filterManager
      * @type WebGLFilterManager
      */
-    this.filterManager = new PIXI.WebGLFilterManager();
+    this.filterManager = new PIXI.WebGLFilterManager(this.resolution);
 
     /**
      * Manages the stencil buffer

--- a/src/pixi/renderers/webgl/utils/WebGLFilterManager.js
+++ b/src/pixi/renderers/webgl/utils/WebGLFilterManager.js
@@ -6,7 +6,7 @@
 * @class WebGLFilterManager
 * @constructor
 */
-PIXI.WebGLFilterManager = function()
+PIXI.WebGLFilterManager = function(resolution)
 {
     /**
      * @property filterStack
@@ -25,6 +25,12 @@ PIXI.WebGLFilterManager = function()
      * @type Number
      */
     this.offsetY = 0;
+
+    /**
+     * @property resolution
+     * @type Number
+     */
+    this.resolution = resolution || 1;
 };
 
 PIXI.WebGLFilterManager.prototype.constructor = PIXI.WebGLFilterManager;
@@ -286,7 +292,7 @@ PIXI.WebGLFilterManager.prototype.popFilter = function()
 
     gl.bufferSubData(gl.ARRAY_BUFFER, 0, this.uvArray);
 
-    gl.viewport(0, 0, sizeX, sizeY);
+    gl.viewport(0, 0, sizeX * this.resolution, sizeY * this.resolution);
 
     // bind the buffer
     gl.bindFramebuffer(gl.FRAMEBUFFER, buffer );


### PR DESCRIPTION
This fixes #1215 and possibly #1286.

I made some assumptions about how to set things up, based on what I've seen before, however the big change is that I did add an optional param to the `WebGLFilterManager` constructor that may or may not be how you guys would like to make this change.