### PR TITLE
Fix WebGLFilterManager to use renderSession.resolution

### DIFF
--- a/src/pixi/renderers/webgl/utils/WebGLFilterManager.js
+++ b/src/pixi/renderers/webgl/utils/WebGLFilterManager.js
@@ -286,7 +286,7 @@ PIXI.WebGLFilterManager.prototype.popFilter = function()
 
     gl.bufferSubData(gl.ARRAY_BUFFER, 0, this.uvArray);
 
-    gl.viewport(0, 0, sizeX, sizeY);
+    gl.viewport(0, 0, sizeX * this.renderSession.resolution, sizeY * this.renderSession.resolution);
 
     // bind the buffer
     gl.bindFramebuffer(gl.FRAMEBUFFER, buffer );


### PR DESCRIPTION
Weird, I thought if I fixed the branch and force pushed, it should've updated #1397.

Perhaps because it was closed?

Anyways, this has been updated as per the discussion.

And for reference, it fixes #1215