### PR TITLE
using a sprite's width/height as default hitArea when provided

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -629,8 +629,8 @@ InteractionManager.prototype.hitTest = function (item, interactionData)
     // a sprite with no hitarea defined
     else if (item instanceof core.Sprite)
     {
-        var width = item.texture.frame.width;
-        var height = item.texture.frame.height;
+        var width = item.width || item.texture.frame.width;
+        var height = item.height || item.texture.frame.height;
         var x1 = -width * item.anchor.x;
         var y1;
 


### PR DESCRIPTION
If no hitArea is provided for a Sprite instance, the InteractionManager uses the Sprite's texture's width and heights as a fallback, .
That works correctly for a basic Sprite, but fails for a TilingSprite. In this case, the provided .width and .height should be used.

Fixes #1132