### PR TITLE
Auto line break with max width in BitmapText

### DIFF
--- a/src/text/BitmapText.js
+++ b/src/text/BitmapText.js
@@ -68,6 +68,14 @@ function BitmapText(text, style)
     this._text = text;
 
     /**
+     * The max width of this bitmap text in pixels. If the text provided is longer than the value provided, line breaks will be automatically inserted in the last whitespace.
+     * Disable by setting value to 0
+     *
+     * @member {number}
+     */
+    this.maxWidth = 0;
+
+    /**
      * The dirty state of this object.
      *
      * @member {boolean}
@@ -181,13 +189,31 @@ BitmapText.prototype.updateText = function ()
     var lineWidths = [];
     var line = 0;
     var scale = this.fontSize / data.size;
+    var lastSpace = -1;
 
     for (var i = 0; i < this.text.length; i++)
     {
         var charCode = this.text.charCodeAt(i);
+        lastSpace = /(\s)/.test(this.text.charAt(i)) ? i : lastSpace;
 
         if (/(?:\r\n|\r|\n)/.test(this.text.charAt(i)))
         {
+            lineWidths.push(lastLineWidth);
+            maxLineWidth = Math.max(maxLineWidth, lastLineWidth);
+            line++;
+
+            pos.x = 0;
+            pos.y += data.lineHeight;
+            prevCharCode = null;
+            continue;
+        }
+
+        if (lastSpace !== -1 && this.maxWidth > 0 && pos.x * scale > this.maxWidth)
+        {
+            chars.splice(lastSpace, i - lastSpace);
+            i = lastSpace;
+            lastSpace = -1;
+
             lineWidths.push(lastLineWidth);
             maxLineWidth = Math.max(maxLineWidth, lastLineWidth);
             line++;


### PR DESCRIPTION
I needed this feature locally so I thought I might as well submit a pull request in case the feature is appreciated by others.