### PR TITLE
Fix temp text fix

### DIFF
--- a/src/text/Text.js
+++ b/src/text/Text.js
@@ -383,7 +383,7 @@ Text.prototype.determineFontProperties = function (fontStyle)
 
         context.font = fontStyle;
 
-        var width = Math.ceil(context.measureText('|Mq').width);
+        var width = Math.ceil(context.measureText('|MÉq').width);
         var baseline = Math.ceil(context.measureText('M').width);
         var height = 2 * baseline;
 
@@ -458,8 +458,6 @@ Text.prototype.determineFontProperties = function (fontStyle)
         }
 
         properties.descent = i - baseline;
-        //TODO might need a tweak. kind of a temp fix!
-        properties.descent += 6;
         properties.fontSize = properties.ascent + properties.descent;
 
         Text.fontPropertiesCache[fontStyle] = properties;


### PR DESCRIPTION
Follow up to https://github.com/GoodBoyDigital/pixi.js/issues/1254

I believe the descender was being drawn off the canvas

Calculating the descender could be optimized by scanning backwards for it, since the q is at the end of the string