### PR TITLE
Specify a module id when defining an AMD module

### DIFF
--- a/src/pixi/Outro.js
+++ b/src/pixi/Outro.js
@@ -8,7 +8,7 @@
         }
         exports.PIXI = PIXI;
     } else if (typeof define !== 'undefined' && define.amd) {
-        define(PIXI);
+        define('pixi', PIXI);
     } else {
         root.PIXI = PIXI;
     }


### PR DESCRIPTION
Some AMD loaders such as almond have problems loading anonymous modules.