### PR TITLE
Matrix.applyInverse bug

### DIFF
--- a/src/core/math/Matrix.js
+++ b/src/core/math/Matrix.js
@@ -149,8 +149,11 @@ Matrix.prototype.applyInverse = function (pos, newPos)
 
     var id = 1 / (this.a * this.d + this.c * -this.b);
 
-    newPos.x = this.d * id * pos.x + -this.c * id * pos.y + (this.ty * this.c - this.tx * this.d) * id;
-    newPos.y = this.a * id * pos.y + -this.b * id * pos.x + (-this.ty * this.a + this.tx * this.b) * id;
+    var x = pos.x;
+    var y = pos.y;
+
+    newPos.x = this.d * id * x + -this.c * id * y + (this.ty * this.c - this.tx * this.d) * id;
+    newPos.y = this.a * id * y + -this.b * id * x + (-this.ty * this.a + this.tx * this.b) * id;
 
     return newPos;
 };


### PR DESCRIPTION
Caches x and y from point so that the calculation is correct even when pos and newPos is the same PIXI.Point.