### PR TITLE
fix PIXI vs CONST reference

### DIFF
--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -144,7 +144,7 @@ var utils = module.exports = {
      */
     getResolutionOfUrl: function (url)
     {
-        var resolution = PIXI.RETINA_PREFIX.exec(url);
+        var resolution = CONST.RETINA_PREFIX.exec(url);
 
         if (resolution)
         {


### PR DESCRIPTION
Just a small thing that popped up in jshint checks 