### PR TITLE
Set pixi.dev.js as value for 'main' within package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "https://github.com/GoodBoyDigital/pixi.js.git"
   },
-  "main": "bin/pixi.js",
+  "main": "bin/pixi.dev.js",
   "scripts": {
     "test": "grunt travis --verbose"
   },


### PR DESCRIPTION
Resolves issue #1449

When using build tools, such as Grunt, alongside Browserify or Uglify it is preferable to target a non-minified PIXI file in order to avoid double minification, since this should be left to an individual's build implementation. So it would be better if the path to the non-minified version of PIXI was set as the value for the 'main' field within the package.json.