### PR TITLE
Double-click support Issue #1386

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -444,11 +444,13 @@ InteractionManager.prototype.processMouseDown = function ( displayObject, hit )
 
             if(this._clickCount === 1)
             {
+                var self = this;
+
                 this._dblClickTimer = setTimeout(function() {
                     displayObject[ isRightButton ? '_isRightDown' : '_isLeftDown' ] = true;
-                    this.dispatchEvent( displayObject, isRightButton ? 'rightdown' : 'mousedown', this.eventData );
-                    this._clickCount = 0;
-                }.bind(this), displayObject.dblClickDelay);
+                    self.dispatchEvent( displayObject, isRightButton ? 'rightdown' : 'mousedown', self.eventData );
+                    self._clickCount = 0;
+                }, displayObject.dblClickDelay);
             }
             else
             {

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -5,7 +5,6 @@ var core = require('../core'),
 // TODO: Obviously rewrite this...
 var INTERACTION_FREQUENCY = 10;
 var AUTO_PREVENT_DEFAULT = true;
-var CLICK_DELAY = 700;
 
 /**
  * The interaction manager deals with mouse and touch events. Any DisplayObject can be interactive
@@ -141,7 +140,7 @@ function InteractionManager( renderer )
      * @member {Number}
      * @private
      */
-    this._doubleClickTimer = null;
+    this._dblClickTimer = null;
 
     /**
      * The current resolution
@@ -445,15 +444,15 @@ InteractionManager.prototype.processMouseDown = function ( displayObject, hit )
 
             if(this._clickCount === 1)
             {
-                this._doubleClickTimer = setTimeout(function() {
+                this._dblClickTimer = setTimeout(function() {
                     displayObject[ isRightButton ? '_isRightDown' : '_isLeftDown' ] = true;
                     this.dispatchEvent( displayObject, isRightButton ? 'rightdown' : 'mousedown', this.eventData );
                     this._clickCount = 0;
-                }.bind(this), CLICK_DELAY);
+                }.bind(this), displayObject.dblClickDelay);
             }
             else
             {
-                clearTimeout(this._doubleClickTimer);
+                clearTimeout(this._dblClickTimer);
                 this.dispatchEvent( displayObject, 'dblclick', this.eventData );
                 this._clickCount = 0;
             }

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -224,13 +224,14 @@ InteractionManager.prototype.removeEvents = function ()
         this.interactionDOMElement.style['-ms-touch-action'] = '';
     }
 
-    this.interactionDOMElement.removeEventListener('mousemove', this.onMouseMove, true);
-    this.interactionDOMElement.removeEventListener('mousedown', this.onMouseDown, true);
-    this.interactionDOMElement.removeEventListener('mouseout',  this.onMouseOut, true);
+    this.interactionDOMElement.removeEventListener('mousemove',  this.onMouseMove, true);
+    this.interactionDOMElement.removeEventListener('mousedown',  this.onMouseDown, true);
+    this.interactionDOMElement.removeEventListener('mouseout',   this.onMouseOut, true);
+    this.interactionDOMElement.removeEventListener('dblclick',   this.onDblClick, true);
 
     this.interactionDOMElement.removeEventListener('touchstart', this.onTouchStart, true);
-    this.interactionDOMElement.removeEventListener('touchend',  this.onTouchEnd, true);
-    this.interactionDOMElement.removeEventListener('touchmove', this.onTouchMove, true);
+    this.interactionDOMElement.removeEventListener('touchend',   this.onTouchEnd, true);
+    this.interactionDOMElement.removeEventListener('touchmove',  this.onTouchMove, true);
 
     this.interactionDOMElement = null;
 
@@ -438,7 +439,7 @@ InteractionManager.prototype.processMouseDown = function ( displayObject, hit )
     {
         // only when the double click callback is defined we should perform
         // the logic for checking double clicks
-        if(displayObject.dblclick)
+        if(displayObject.dblclick || displayObject._listeners.dblclick)
         {
             this._clickCount++;
 
@@ -473,9 +474,14 @@ InteractionManager.prototype.processMouseDown = function ( displayObject, hit )
  * @param event {Event} The DOM event of a mouse button being double pressed down
  * @private
  */
-InteractionManager.prototype.onDblClick = function (event) {
+InteractionManager.prototype.onDblClick = function (event)
+{
     this.mouse.originalEvent = event;
-    this.mouse.originalEvent.preventDefault();
+
+    if (AUTO_PREVENT_DEFAULT)
+    {
+        this.mouse.originalEvent.preventDefault();
+    }
 };
 
 /**

--- a/src/interaction/interactiveTarget.js
+++ b/src/interaction/interactiveTarget.js
@@ -2,7 +2,7 @@ var core = require('../core');
 
 
 core.DisplayObject.prototype.interactive = false;
-core.DisplayObject.prototype.dblClickDelay = 700;
+core.DisplayObject.prototype.dblClickDelay = 300;
 core.DisplayObject.prototype.buttonMode = false;
 core.DisplayObject.prototype.interactiveChildren = true;
 core.DisplayObject.prototype.defaultCursor = 'pointer';

--- a/src/interaction/interactiveTarget.js
+++ b/src/interaction/interactiveTarget.js
@@ -2,6 +2,7 @@ var core = require('../core');
 
 
 core.DisplayObject.prototype.interactive = false;
+core.DisplayObject.prototype.dblClickDelay = 700;
 core.DisplayObject.prototype.buttonMode = false;
 core.DisplayObject.prototype.interactiveChildren = true;
 core.DisplayObject.prototype.defaultCursor = 'pointer';


### PR DESCRIPTION
Added a double click event.

Example use:

```javascript
// set the delay between clicks
sprite.dblClickDelay = 200; // defaults to 300ms

// set the callback function
sprite.dblclick = function() {
....
};

// or

sprite.on('dblclick', function() {
....
});
```

**In the below gif, the tint changes when the double click event fires**
![pixi_dblclick](https://cloud.githubusercontent.com/assets/3887730/6454265/af0e47c6-c19b-11e4-9247-be541e9781bd.gif)

Issue: https://github.com/GoodBoyDigital/pixi.js/issues/1386