### PR TITLE
Fix a typo from "AssetsLoader" to "AssetLoader"

### DIFF
--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -13,7 +13,7 @@ core.SpriteBatch = function ()
     window.console.warn('SpriteBatch does not exist any more, please use the new ParticleContainer instead.');
 };
 
-core.AssetsLoader = function () {
+core.AssetLoader = function () {
     window.console.warn('The loader system was overhauled in pixi v3, please see the new PIXI.Loader class.');
 };
 


### PR DESCRIPTION
Hi.
We use "AssetLoader" in 2.x, not "AssetsLoader".