### PR TITLE
`copy` and `equals` methods for the Point object

### DIFF
--- a/src/core/math/Point.js
+++ b/src/core/math/Point.js
@@ -36,6 +36,25 @@ Point.prototype.clone = function ()
 };
 
 /**
+ * Copies x and y from the given point
+ *
+ * @param p {Point}
+ */
+Point.prototype.copy = function (p) {
+    this.set(p.x, p.y);
+};
+
+/**
+ * Returns true if the given point is equal to this point
+ *
+ * @param p {Point}
+ * @returns {boolean}
+ */
+Point.prototype.equals = function (p) {
+    return (p.x === this.x) && (p.y === this.y);
+};
+
+/**
  * Sets the point to a new x and y position.
  * If y is omitted, both x and y will be set to x.
  *


### PR DESCRIPTION
Hello!
I suggest to add `copy` and `equals` methods to the Point.
Why can't we have such useful methods in the Point object?
I followed the development before and saw that you didn't want to overload this object with unnecessary methods and suggested to create own extended Point instead. But...
Maybe it's just me but I use such operations A LOT. For example I use Point to represent position on the tilemap and in this case `equals` method could be very useful. But it seems to be a minor overkill to create own object for that purpose.
Also when you create some object and want to place it on the same position as the "creator" like this:

```
var o = new Entity();
o.x = this.x;
o.y = this.y;
```

I should be more efficent to make it like this

```
o.position.copy(this.position);
```

instead of 

```
o.position = this.position.clone();
```

Tell me if I'm wrong about all this stuff.