### PR TITLE
RetinaPrefix as part of rendering options

### DIFF
--- a/src/core/const.js
+++ b/src/core/const.js
@@ -128,6 +128,7 @@ module.exports = {
     DEFAULT_RENDER_OPTIONS: {
         view: null,
         resolution: 1,
+        retinaPrefix: /@(.+)x/,
         antialias: false,
         forceFXAA: false,
         autoResize: false,

--- a/src/core/const.js
+++ b/src/core/const.js
@@ -94,15 +94,6 @@ module.exports = {
         NEAREST:    1
     },
 
-    /**
-     * The prefix that denotes a URL is for a retina asset
-     *
-     * @static
-     * @property {string} RETINA_PREFIX
-     */
-    //example: '@2x',
-    RETINA_PREFIX: /@(.+)x/,
-
     RESOLUTION:1,
 
     FILTER_RESOLUTION:1,

--- a/src/core/const.js
+++ b/src/core/const.js
@@ -98,7 +98,6 @@ module.exports = {
      * The prefix that denotes a URL is for a retina asset
      *
      * @static
-     * @constant
      * @property {string} RETINA_PREFIX
      */
     //example: '@2x',
@@ -121,6 +120,7 @@ module.exports = {
      * @property {boolean} DEFAULT_RENDER_OPTIONS.forceFXAA=false
      * @property {boolean} DEFAULT_RENDER_OPTIONS.preserveDrawingBuffer=false
      * @property {number} DEFAULT_RENDER_OPTIONS.resolution=1
+     * @property {number} DEFAULT_RENDER_OPTIONS.retinaPrefix=/@(.+)x/
      * @property {number} DEFAULT_RENDER_OPTIONS.backgroundColor=0x000000
      * @property {boolean} DEFAULT_RENDER_OPTIONS.clearBeforeRender=true
      * @property {boolean} DEFAULT_RENDER_OPTIONS.autoResize=false

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -65,6 +65,7 @@ var core = module.exports = {
      * @param [options.preserveDrawingBuffer=false] {boolean} enables drawing buffer preservation, enable this if you
      *      need to call toDataUrl on the webgl context
      * @param [options.resolution=1] {number} the resolution of the renderer, retina would be 2
+     * @param [options.retinaPrefix=/@(.+)x/] {string} the prefix that denotes a URL is for a retina asset
      * @param [noWebGL=false] {boolean} prevents selection of WebGL renderer, even if such is present
      *
      * @return {WebGLRenderer|CanvasRenderer} Returns WebGL renderer if available, otherwise CanvasRenderer

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -46,7 +46,7 @@ function SystemRenderer(system, width, height, options)
 
     if (options.retinaPrefix !== null)
     {
-        CONST.RETINA_PREFIX = options.retinaPrefix;
+        utils.retinaPrefix = options.retinaPrefix;
     }
 
     /**

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -18,6 +18,7 @@ var utils = require('../utils'),
  * @param [options.autoResize=false] {boolean} If the render view is automatically resized, default false
  * @param [options.antialias=false] {boolean} sets antialias (only applicable in chrome at the moment)
  * @param [options.resolution=1] {number} the resolution of the renderer retina would be 2
+ * @param [options.retinaPrefix=/@(.+)x/] {string} the prefix that denotes a URL is for a retina asset
  * @param [options.clearBeforeRender=true] {boolean} This sets if the CanvasRenderer will clear the canvas or
  *      not before the new render pass.
  */
@@ -41,6 +42,11 @@ function SystemRenderer(system, width, height, options)
     else
     {
         options = CONST.DEFAULT_RENDER_OPTIONS;
+    }
+
+    if (options.retinaPrefix !== null)
+    {
+        CONST.RETINA_PREFIX = options.retinaPrefix;
     }
 
     /**

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -19,6 +19,7 @@ var SystemRenderer = require('../SystemRenderer'),
  * @param [options.autoResize=false] {boolean} If the render view is automatically resized, default false
  * @param [options.antialias=false] {boolean} sets antialias (only applicable in chrome at the moment)
  * @param [options.resolution=1] {number} the resolution of the renderer retina would be 2
+ * @param [options.retinaPrefix=/@(.+)x/] {string} the prefix that denotes a URL is for a retina asset
  * @param [options.clearBeforeRender=true] {boolean} This sets if the CanvasRenderer will clear the canvas or
  *      not before the new render pass.
  */

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -28,6 +28,7 @@ var SystemRenderer = require('../SystemRenderer'),
  * @param [options.antialias=false] {boolean} sets antialias. If not available natively then FXAA antialiasing is used
  * @param [options.forceFXAA=false] {boolean} forces FXAA antialiasing to be used over native. FXAA is faster, but may not always lok as great
  * @param [options.resolution=1] {number} the resolution of the renderer retina would be 2
+ * @param [options.retinaPrefix=/@(.+)x/] {string} the prefix that denotes a URL is for a retina asset
  * @param [options.clearBeforeRender=true] {boolean} This sets if the CanvasRenderer will clear the canvas or
  *      not before the new render pass.
  * @param [options.preserveDrawingBuffer=false] {boolean} enables drawing buffer preservation, enable this if

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -10,6 +10,15 @@ var utils = module.exports = {
     pluginTarget:   require('./pluginTarget'),
     PolyK:          require('./PolyK'),
 
+    /**
+     * The prefix that denotes a URL is for a retina asset
+     *
+     * @static
+     * @property {string} retinaPrefix
+     */
+    //example: '@2x',
+    retinaPrefix: /@(.+)x/,
+
 
     /**
      * Gets the next uuid
@@ -146,7 +155,7 @@ var utils = module.exports = {
      */
     getResolutionOfUrl: function (url)
     {
-        var resolution = CONST.RETINA_PREFIX.exec(url);
+        var resolution = utils.retinaPrefix.exec(url);
 
         if (resolution)
         {


### PR DESCRIPTION
- added retinaPrefix as part of rendering options so that it can be customised

Not sure if this the right way to do it, but I thought providing a way to specify regex for retina assets is very useful.

Please review and let me know if this is ok.

I did try overwriting RETINA_PREFIX in constants and it works but it's a hack as it was defined as a static constant and you don't want to overwrite that at runtime.