### PR TITLE
clamped filterArea dimensions to positive values

### DIFF
--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -376,6 +376,9 @@ FilterManager.prototype.capFilterArea = function (filterArea)
     {
         filterArea.height = this.textureSize.height - filterArea.y;
     }
+
+    filterArea.width = Math.max(0, filterArea.width);
+    filterArea.height = Math.max(0, filterArea.height);
 };
 
 /*


### PR DESCRIPTION
This prevents the WebGL error discussed in #1547 by clamping the viewport dimensions to positive values. I suspect you'd want to prevent the render pass completely if the viewport has 0 width and height, but I've not dug that deep myself yet.