### PR TITLE
Feature/object assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "async": "^0.9.0",
     "brfs": "^1.2.0",
     "eventemitter3": "^0.1.6",
-    "extend": "^2.0.0",
+    "object-assign": "^2.0.0",
     "resource-loader": "^1.3.0"
   },
   "devDependencies": {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -5,14 +5,12 @@
  * @license     {@link https://github.com/GoodBoyDigital/pixi.js/blob/master/LICENSE|MIT License}
  */
 
-var utils = require('./utils');
-
 /**
  * @namespace PIXI
  */
 var core = {
     // utils
-    utils: utils,
+    utils: require('./utils'),
     math: require('./math'),
     CONST: require('./const'),
 
@@ -76,7 +74,7 @@ var core = {
         width = width || 800;
         height = height || 600;
 
-        if (!noWebGL && utils.isWebGLSupported())
+        if (!noWebGL && core.utils.isWebGLSupported())
         {
             return new core.WebGLRenderer(width, height, options);
         }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -5,8 +5,7 @@
  * @license     {@link https://github.com/GoodBoyDigital/pixi.js/blob/master/LICENSE|MIT License}
  */
 
-var extend = require('extend'),
-    utils = require('./utils');
+var utils = require('./utils');
 
 /**
  * @namespace PIXI
@@ -86,5 +85,5 @@ var core = {
     }
 };
 
-// export core and const. We extend into const so that the non-reference types in const remain in-tact
-module.exports = extend(require('./const'), core);
+// export core and const. We assign core to const so that the non-reference types in const remain in-tact
+module.exports = Object.assign(require('./const'), core);

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 require('./polyfill');
 
 var core = require('./core'),
-	assign = Object.assign;
+    assign = Object.assign;
 
 assign(core, require('./core/math'));
 assign(core, require('./extras'));

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,17 @@
 // run the polyfills
 require('./polyfill');
 
-var extend = require('extend'),
-    core = require('./core');
+var core = require('./core'),
+	assign = Object.assign;
 
-extend(core, require('./core/math'));
-extend(core, require('./extras'));
-extend(core, require('./mesh'));
-extend(core, require('./filters'));
-extend(core, require('./interaction'));
-extend(core, require('./loaders'));
-extend(core, require('./spine'));
-extend(core, require('./text'));
-extend(core, require('./deprecation'));
+assign(core, require('./core/math'));
+assign(core, require('./extras'));
+assign(core, require('./mesh'));
+assign(core, require('./filters'));
+assign(core, require('./interaction'));
+assign(core, require('./loaders'));
+assign(core, require('./spine'));
+assign(core, require('./text'));
+assign(core, require('./deprecation'));
 
 module.exports = core;

--- a/src/polyfill/Object.assign.js
+++ b/src/polyfill/Object.assign.js
@@ -1,0 +1,3 @@
+if (!Object.assign) {
+	Object.assign = require('object-assign');
+}

--- a/src/polyfill/Object.assign.js
+++ b/src/polyfill/Object.assign.js
@@ -1,3 +1,8 @@
-if (!Object.assign) {
-	Object.assign = require('object-assign');
+// References:
+// https://github.com/sindresorhus/object-assign
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+
+if (!Object.assign)
+{
+    Object.assign = require('object-assign');
 }

--- a/src/polyfill/index.js
+++ b/src/polyfill/index.js
@@ -1,1 +1,2 @@
+require('./Object.assign');
 require('./requestAnimationFrame');


### PR DESCRIPTION
Changed from extend module in favor of Object.assign polyfill using [this package](https://github.com/sindresorhus/object-assign). I know no syntactical ES6 features, but this one is an easy IE9+ polyfill and is always useful.

Also minor change to use `core.utils` ref instead of `utils` ref in core/index.js.