### PR TITLE
Feature/cleanup

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -37,6 +37,7 @@ var core = module.exports = Object.assign(require('./const'), require('./math'),
     BaseTexture:            require('./textures/BaseTexture'),
     RenderTexture:          require('./textures/RenderTexture'),
     VideoBaseTexture:       require('./textures/VideoBaseTexture'),
+    TextureUvs:             require('./textures/TextureUvs'),
 
     // renderers - canvas
     CanvasRenderer:         require('./renderers/canvas/CanvasRenderer'),

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -105,5 +105,3 @@ core.Text.prototype.setText = function (text)
     this.text = text;
     console.warn('setText is now deprecated, please use the text property, e.g : myText.text = \'my text\';');
 };
-
-module.exports = {};

--- a/src/extras/TilingSprite.js
+++ b/src/extras/TilingSprite.js
@@ -1,5 +1,4 @@
 var core = require('../core'),
-    TextureUvs = require('../core/textures/TextureUvs'),
     // a sprite use dfor rendering textures..
     tempSprite = new core.Sprite(),
     tempPoint = new core.Point(),
@@ -83,7 +82,7 @@ function TilingSprite(texture, width, height)
      * @member {TextureUvs}
      * @private
      */
-    this._uvs = new TextureUvs();
+    this._uvs = new core.TextureUvs();
 }
 
 TilingSprite.prototype = Object.create(core.Sprite.prototype);

--- a/src/extras/TilingSprite.js
+++ b/src/extras/TilingSprite.js
@@ -1,6 +1,5 @@
 var core = require('../core'),
     TextureUvs = require('../core/textures/TextureUvs'),
-    RenderTexture = require('../core/textures/RenderTexture'),
     // a sprite use dfor rendering textures..
     tempSprite = new core.Sprite(),
     tempPoint = new core.Point(),
@@ -379,7 +378,7 @@ TilingSprite.prototype.generateTilingTexture = function (renderer, texture, forc
         tempSprite.texture = texture;
 
         //TODO not create a new one each time you refresh
-        var renderTexture = new RenderTexture(renderer, targetWidth, targetHeight, texture.baseTexture.scaleMode, texture.baseTexture.resolution);
+        var renderTexture = new core.RenderTexture(renderer, targetWidth, targetHeight, texture.baseTexture.scaleMode, texture.baseTexture.resolution);
 
         var cachedRenderTarget = renderer.currentRenderTarget;
 

--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -1,9 +1,6 @@
-var math = require('../core/math'),
-    RenderTexture = require('../core/textures/RenderTexture'),
-    DisplayObject = require('../core/display/DisplayObject'),
-    Sprite = require('../core/sprites/Sprite'),
-
-    _tempMatrix = new math.Matrix();
+var core = require('../core'),
+    DisplayObject = core.DisplayObject,
+    _tempMatrix = new core.Matrix();
 
 DisplayObject.prototype._cacheAsBitmap = false;
 DisplayObject.prototype._originalRenderWebGL = null;
@@ -13,10 +10,7 @@ DisplayObject.prototype._originalUpdateTransform = null;
 DisplayObject.prototype._originalHitTest = null;
 DisplayObject.prototype._cachedSprite = null;
 
-
-
 Object.defineProperties(DisplayObject.prototype, {
-
 
     /**
      * Set this to true if you want this display object to be cached as a bitmap.
@@ -130,7 +124,7 @@ DisplayObject.prototype._initCachedDisplayObject = function( renderer )
     var stack = renderer.filterManager.filterStack;
 
     // this renderTexture will be used to store the cached DisplayObject
-    var renderTexture = new RenderTexture(renderer, bounds.width | 0, bounds.height | 0);
+    var renderTexture = new core.RenderTexture(renderer, bounds.width | 0, bounds.height | 0);
 
     // need to set //
     var m = _tempMatrix;
@@ -155,7 +149,7 @@ DisplayObject.prototype._initCachedDisplayObject = function( renderer )
 
 
     // create our cached sprite
-    this._cachedSprite = new Sprite(renderTexture);
+    this._cachedSprite = new core.Sprite(renderTexture);
     this._cachedSprite.worldTransform = this.worldTransform;
     this._cachedSprite.anchor.x = -( bounds.x / bounds.width );
     this._cachedSprite.anchor.y = -( bounds.y / bounds.height );
@@ -198,7 +192,7 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function( renderer )
 
     var cachedRenderTarget = renderer.context;
 
-    var renderTexture = new RenderTexture(renderer, bounds.width | 0, bounds.height | 0);
+    var renderTexture = new core.RenderTexture(renderer, bounds.width | 0, bounds.height | 0);
 
     // need to set //
     var m = _tempMatrix;
@@ -220,7 +214,7 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function( renderer )
 
 
     // create our cached sprite
-    this._cachedSprite = new Sprite(renderTexture);
+    this._cachedSprite = new core.Sprite(renderTexture);
     this._cachedSprite.worldTransform = this.worldTransform;
     this._cachedSprite.anchor.x = -( bounds.x / bounds.width );
     this._cachedSprite.anchor.y = -( bounds.y / bounds.height );
@@ -249,7 +243,3 @@ DisplayObject.prototype._destroyCachedDisplayObject = function()
     this._cachedSprite._texture.destroy();
     this._cachedSprite = null;
 };
-
-
-
-module.exports = {};

--- a/src/extras/getChildByName.js
+++ b/src/extras/getChildByName.js
@@ -1,12 +1,11 @@
-var DisplayObject = require('../core/display/DisplayObject'),
-    Container = require('../core/display/Container');
+var core = require('../core');
 
 /**
  * The instance name of the object.
  *
  * @member {string}
  */
-DisplayObject.prototype.name = null;
+core.DisplayObject.prototype.name = null;
 
 /**
 * Returns the display object in the container
@@ -14,7 +13,7 @@ DisplayObject.prototype.name = null;
 * @param name {string} instance name
 * @return {DisplayObject}
 */
-Container.prototype.getChildByName = function (name)
+core.Container.prototype.getChildByName = function (name)
 {
     for (var i = 0; i < this.children.length; i++) 
     {
@@ -25,5 +24,3 @@ Container.prototype.getChildByName = function (name)
     }
     return null;
 };
-
-module.exports = {};

--- a/src/extras/getGlobalPosition.js
+++ b/src/extras/getGlobalPosition.js
@@ -1,6 +1,4 @@
-var DisplayObject = require('../core/display/DisplayObject'),
-    Point = require('../core/math/Point');
-
+var core = require('../core');
 
 /**
 * Returns the global position of the displayObject
@@ -8,9 +6,9 @@ var DisplayObject = require('../core/display/DisplayObject'),
 * @param point {Point} the point to write the global value to. If null a new point will be returned
 * @return {Point}
 */
-DisplayObject.prototype.getGlobalPosition = function (point)
+core.DisplayObject.prototype.getGlobalPosition = function (point)
 {
-    point = point || new Point();
+    point = point || new core.Point();
 
     if(this.parent)
     {
@@ -27,5 +25,3 @@ DisplayObject.prototype.getGlobalPosition = function (point)
 
     return point;
 };
-
-module.exports = {};

--- a/src/extras/index.js
+++ b/src/extras/index.js
@@ -5,6 +5,10 @@
  * @license     {@link https://github.com/GoodBoyDigital/pixi.js/blob/master/LICENSE|MIT License}
  */
 
+require('./cacheAsBitmap'),
+require('./getChildByName');
+require('./getGlobalPosition');
+
 /**
  * @namespace PIXI.extras
  */
@@ -13,7 +17,4 @@ module.exports = {
     MovieClip:      require('./MovieClip'),
     TilingSprite:   require('./TilingSprite'),
     BitmapText:     require('./BitmapText'),
-    cacheAsBitmap:  require('./cacheAsBitmap'),
-    getChildByName: require('./getChildByName'),
-    getGlobalPosition: require('./getGlobalPosition')
 };

--- a/src/extras/index.js
+++ b/src/extras/index.js
@@ -5,7 +5,7 @@
  * @license     {@link https://github.com/GoodBoyDigital/pixi.js/blob/master/LICENSE|MIT License}
  */
 
-require('./cacheAsBitmap'),
+require('./cacheAsBitmap');
 require('./getChildByName');
 require('./getGlobalPosition');
 

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -1,6 +1,12 @@
 var core = require('../core'),
     InteractionData = require('./InteractionData');
 
+// Mix interactiveTarget into core.DisplayObject.prototype
+Object.assign(
+    core.DisplayObject.prototype,
+    require('./interactiveTarget')
+);
+
 /**
  * The interaction manager deals with mouse and touch events. Any DisplayObject can be interactive
  * if its interactive parameter is set to true

--- a/src/interaction/interactiveTarget.js
+++ b/src/interaction/interactiveTarget.js
@@ -17,19 +17,19 @@ module.exports = {
     /**
      * @todo
      */
-    interactive: false;
+    interactive: false,
     /**
      * @todo
      */
-    buttonMode: false;
+    buttonMode: false,
     /**
      * @todo
      */
-    interactiveChildren: true;
+    interactiveChildren: true,
     /**
      * @todo
      */
-    defaultCursor: 'pointer';
+    defaultCursor: 'pointer',
 
     // some internal checks..
 
@@ -37,10 +37,10 @@ module.exports = {
      * @todo
      * @private
      */
-    _over: false;
+    _over: false,
     /**
      * @todo
      * @private
      */
-    _touchDown: false;
+    _touchDown: false
 };

--- a/src/interaction/interactiveTarget.js
+++ b/src/interaction/interactiveTarget.js
@@ -1,13 +1,46 @@
-var core = require('../core');
+/**
+ * Default property values of interactive objects
+ * used by {@link PIXI.interaction.InteractionManager}.
+ *
+ * @mixin
+ * @memberof PIXI.interaction
+ * @example
+ *      function MyObject() {}
+ *
+ *      Object.assign(
+ *          MyObject.prototype,
+ *          PIXI.interaction.interactiveTarget)
+ *      );
+ */
 
+module.exports = {
+    /**
+     * @todo
+     */
+    interactive: false;
+    /**
+     * @todo
+     */
+    buttonMode: false;
+    /**
+     * @todo
+     */
+    interactiveChildren: true;
+    /**
+     * @todo
+     */
+    defaultCursor: 'pointer';
 
-core.DisplayObject.prototype.interactive = false;
-core.DisplayObject.prototype.buttonMode = false;
-core.DisplayObject.prototype.interactiveChildren = true;
-core.DisplayObject.prototype.defaultCursor = 'pointer';
+    // some internal checks..
 
-// some internal checks..
-core.DisplayObject.prototype._over = false;
-core.DisplayObject.prototype._touchDown = false;
-
-module.exports = {};
+    /**
+     * @todo
+     * @private
+     */
+    _over: false;
+    /**
+     * @todo
+     * @private
+     */
+    _touchDown: false;
+};


### PR DESCRIPTION
No need to define `module.exports = {}` for modules that don't export, modules are always provided with a default empty object via `exports`. Also no need to further export an empty module for up through the dependency tree just requiring will suffice.

The extra modules were getting confusing in how they were bypassing the separation of concerns. I didn't think they should be reaching into the core modules like that. The only one I left was the TextureUv reach in, but I was also tempted to expose that from core to get all of them. What I am trying to help here is maintaining the api contract set by core/index. Use what and how it exports its internal modules, rather than bypassing it.