### PR TITLE
RenderTexture now checks whether the display object its rendering has children.

### DIFF
--- a/src/core/textures/RenderTexture.js
+++ b/src/core/textures/RenderTexture.js
@@ -270,7 +270,7 @@ RenderTexture.prototype.renderWebGL = function (displayObject, matrix, clear, up
 
         // Time to update all the children of the displayObject with the new matrix..
         var children = displayObject.children;
-        if (children)
+        if (children && children.length > 0)
         {
             var i, j;
 
@@ -329,7 +329,7 @@ RenderTexture.prototype.renderCanvas = function (displayObject, matrix, clear, u
 
     // Time to update all the children of the displayObject with the new matrix..
     var children = displayObject.children;
-    if (children)
+    if (children && children.length > 0)
     {
         var i, j;
 

--- a/src/core/textures/RenderTexture.js
+++ b/src/core/textures/RenderTexture.js
@@ -270,11 +270,18 @@ RenderTexture.prototype.renderWebGL = function (displayObject, matrix, clear, up
 
         // Time to update all the children of the displayObject with the new matrix..
         var children = displayObject.children;
-        var i, j;
-
-        for (i = 0, j = children.length; i < j; ++i)
+        if (children)
         {
-            children[i].updateTransform();
+            var i, j;
+
+            for (i = 0, j = children.length; i < j; ++i)
+            {
+                children[i].updateTransform();
+            }
+        }
+        else
+        {
+            displayObject.updateTransform();
         }
     }
 
@@ -322,11 +329,18 @@ RenderTexture.prototype.renderCanvas = function (displayObject, matrix, clear, u
 
     // Time to update all the children of the displayObject with the new matrix..
     var children = displayObject.children;
-    var i, j;
-
-    for (i = 0, j = children.length; i < j; ++i)
+    if (children)
     {
-        children[i].updateTransform();
+        var i, j;
+
+        for (i = 0, j = children.length; i < j; ++i)
+        {
+            children[i].updateTransform();
+        }
+    }
+    else
+    {
+        displayObject.updateTransform();
     }
 
     if (clear)


### PR DESCRIPTION
RenderTexture now checks whether the display object its rendering has children or not.

Issue: https://github.com/GoodBoyDigital/pixi.js/issues/1537