### PR TITLE
Fix resource caching only by url and never by name / key if provided

### DIFF
--- a/src/loaders/textureParser.js
+++ b/src/loaders/textureParser.js
@@ -8,8 +8,9 @@ module.exports = function ()
         if (resource.data && resource.data.nodeName && resource.data.nodeName.toLowerCase() === 'img')
         {
             resource.texture = new core.Texture(new core.BaseTexture(resource.data, null, core.utils.getResolutionOfUrl(resource.url)));
-            // lets also add the frame to pixi's global cache for fromFrame and fromImage fucntions
-            core.utils.TextureCache[resource.url] = resource.texture;
+            // lets also add the frame to pixi's global cache for fromFrame and fromImage functions
+            // retrieve resource.name to let possibility using key or raw url
+            core.utils.TextureCache[resource.name] = resource.texture;
         }
 
         next();


### PR DESCRIPTION
This wasn't working

```javascript
PIXI.loader.add( { name: "my_image", url: "complex/url/of/death.png" } )
PIXI.loader.load();

var sprite = new PIXI.Sprite.fromImage( "my_image" ); // only complex/url/of/death.png was working
```

Of course using the other way with url inside sprite still work if you didn't set a name or key when using add.