### PR TITLE
cacheAsBitmap should respect .visible property

### DIFF
--- a/bin/pixi.js
+++ b/bin/pixi.js
@@ -21379,6 +21379,11 @@ Object.defineProperties(DisplayObject.prototype, {
 */
 DisplayObject.prototype._renderCachedWebGL = function(renderer)
 {
+    if (!this.visible || this.worldAlpha <= 0)
+    {
+        return;
+    }
+    
     this._initCachedDisplayObject( renderer );
 
     this._cachedSprite.worldAlpha = this.worldAlpha;
@@ -21472,6 +21477,11 @@ DisplayObject.prototype._initCachedDisplayObject = function( renderer )
 */
 DisplayObject.prototype._renderCachedCanvas = function(renderer)
 {
+    if (!this.visible || this.worldAlpha <= 0)
+    {
+        return;
+    }
+    
     this._initCachedDisplayObjectCanvas( renderer );
 
     this._cachedSprite.worldAlpha = this.worldAlpha;


### PR DESCRIPTION
It seems to me that even when an object is set with the cacheAsBitmap property, it should be able to respond to changes in its .visible property instantly, just as it already does with the .alpha property. This change checks the .visible property before rendering a cached bitmap, like other objects already do.