### PR TITLE
Use removeListener instead of remove in PIXI.Texture.destroy.

### DIFF
--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -239,8 +239,8 @@ Texture.prototype.destroy = function (destroyBase)
         this.baseTexture.destroy();
     }
 
-    this.baseTexture.remove('update', this.onBaseTextureUpdated, this);
-    this.baseTexture.remove('loaded', this.onBaseTextureLoaded, this);
+    this.baseTexture.removeListener('update', this.onBaseTextureUpdated, this);
+    this.baseTexture.removeListener('loaded', this.onBaseTextureLoaded, this);
 
     this.valid = false;
 };


### PR DESCRIPTION
### Related To:
https://github.com/GoodBoyDigital/pixi.js/issues/1667

### Comments:
- Use `removeListener` over `remove`.