### PR TITLE
Another short hand way for creating movieclips

### DIFF
--- a/src/pixi/display/MovieClip.js
+++ b/src/pixi/display/MovieClip.js
@@ -205,3 +205,37 @@ PIXI.MovieClip.fromImages = function(images)
 
     return new PIXI.MovieClip(textures);
 };
+
+/**
+ * A short hand way of creating a movieclip from frames number, frame base name, frame number padding and image extension
+ *
+ * @static
+ * @method fromSettings
+ * @param framesNum {Number} Number of movieclip frames
+ * @param baseName {String} Base name of each frame.
+ * @param padding {String} Frames number padding (when each frame is something like 0000, 0001, 0002, 0003, etc. - padding 0000)
+ * @param firstFrame {Number} Which is first frame. Default is 0.
+ * @param frameExtension {String} Extension added to each frame's name.
+ * @return {MovieClip}
+ */
+PIXI.MovieClip.fromSettings = function( framesNum, baseName, padding, firstFrame, frameExtension )
+{
+    var textures = [];
+
+    var generateFrameName = function( frame ) {
+        var name = baseName;
+        if (padding) {
+            name += padding.substring(0, padding.length - frame.length) + frame;
+        }
+        if (frameExtension) {
+            name += frameExtension;
+        }
+        return name;
+    };
+
+    for (var i = firstFrame || 0; i < framesNum; i++) {
+        textures.push(PIXI.Texture.fromFrame( generateFrameName( i.toString() ) ));
+    }
+
+    return new PIXI.MovieClip(textures);
+};


### PR DESCRIPTION
It's useful when you create a movieclip from sprites exported by https://www.codeandweb.com/texturepacker or other similar software and all frames for the movie clip are in single json file and has similar frame names. For example: frame0000.png, frame0001.png, frame0002.png, frame0004.png, etc.
Then you can just call PIXI.MovieClip.fromSettings(5, 'frame', '0000', 0, '.png');
Maybe the name "fromSettings" is not the best choise, but I could not think of a better name, so any suggestions for changes in the comment, function name, parameters names, etc are appreciated.