### PR TITLE
More Ticker changes

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -37,6 +37,7 @@
     "maxcomplexity" : false,    // Restrict the cyclomatic complexity of the code.
     "maxlen"        : 220,      // Require that all lines are 100 characters or less.
     "globals"       : {         // Register globals that are used in the code.
+        "performance": false    // Depends on polyfill, simplifies usage
     },
 
     // == Relaxing Options ================================================

--- a/src/core/const.js
+++ b/src/core/const.js
@@ -35,6 +35,15 @@ module.exports = {
     DEG_TO_RAD: Math.PI / 180,
 
     /**
+     * Target frames per millisecond.
+     *
+     * @static
+     * @constant
+     * @property {number} TARGET_FPMS=0.06
+     */
+    TARGET_FPMS: 0.06,
+
+    /**
      * Constant to identify the Renderer Type.
      *
      * @static
@@ -178,5 +187,7 @@ module.exports = {
         RREC: 4
     },
 
+    // TODO: maybe change to SPRITE.BATCH_SIZE: 2000
+    // TODO: maybe add PARTICLE.BATCH_SIZE: 15000
     SPRITE_BATCH_SIZE: 2000 //nice balance between mobile and desktop machines
 };

--- a/src/extras/MovieClip.js
+++ b/src/extras/MovieClip.js
@@ -1,5 +1,5 @@
 var core    = require('../core'),
-    Ticker  = require('./Ticker');
+    ticker  = require('../ticker');
 
 /**
  * A MovieClip is a simple way to display an animation depicted by a list of textures.
@@ -129,7 +129,7 @@ MovieClip.prototype.stop = function ()
     }
 
     this.playing = false;
-    Ticker.sharedTicker.remove(this.update);
+    ticker.shared.remove(this.update);
 };
 
 /**
@@ -144,7 +144,7 @@ MovieClip.prototype.play = function ()
     }
 
     this.playing = true;
-    Ticker.sharedTicker.add(this.update, this);
+    ticker.shared.add(this.update, this);
 };
 
 /**

--- a/src/extras/Ticker.js
+++ b/src/extras/Ticker.js
@@ -151,7 +151,8 @@ Object.defineProperties(Ticker.prototype, {
         },
         set: function(fps)
         {
-            var minFPMS = Math.min(fps / 1000, core.TARGET_FPMS);
+            // Clamp: 0 to TARGET_FPMS
+            var minFPMS = Math.min(Math.max(0, fps) / 1000, core.TARGET_FPMS);
             this._maxElapsedMS = 1 / minFPMS;
         }
     }

--- a/src/extras/index.js
+++ b/src/extras/index.js
@@ -13,7 +13,6 @@ require('./getGlobalPosition');
  * @namespace PIXI.extras
  */
 module.exports = {
-    Ticker:         require('./Ticker'),
     MovieClip:      require('./MovieClip'),
     TilingSprite:   require('./TilingSprite'),
     BitmapText:     require('./BitmapText'),

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ core.interaction    = require('./interaction');
 core.loaders        = require('./loaders');
 core.mesh           = require('./mesh');
 core.spine          = require('pixi-spine');
+core.ticker         = require('./ticker');
 
 // export a premade loader instance
 core.loader = new core.loaders.Loader();

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -91,14 +91,6 @@ function InteractionManager(renderer, options)
      */
     this.eventsAdded = false;
 
-    /**
-     * The ID of the requestAnimationFrame call, so we can clear it in destroy.
-     *
-     * @member {number}
-     * @private
-     */
-    this.requestId = 0;
-
     //this will make it so that you don't have to call bind all the time
 
     /**
@@ -169,21 +161,28 @@ function InteractionManager(renderer, options)
      */
     this.resolution = 1;
 
-    /**
-     * The update method bound to our context.
-     *
-     * @member {function}
-     * @private
-     */
-    this.updateBound = this.update.bind(this);
-
     this.setTargetElement(this.renderer.view, this.renderer.resolution);
-
-    this.update();
 }
 
 InteractionManager.prototype.constructor = InteractionManager;
 module.exports = InteractionManager;
+
+/**
+ * Ensures the interaction checks don't happen too often by delaying the update loop
+ *
+ * @private
+ */
+InteractionManager.prototype._tick = function (deltaTime)
+{
+    this._deltaTime += deltaTime;
+
+    if (this._deltaTime < this.interactionFrequency)
+    {
+        return;
+    }
+
+    this.update();
+};
 
 /**
  * Sets the DOM element which will receive mouse/touch events. This is useful for when you have
@@ -216,6 +215,8 @@ InteractionManager.prototype.addEvents = function ()
         return;
     }
 
+    core.ticker.shared.add(this._tick, this);
+
     if (window.navigator.msPointerEnabled)
     {
         this.interactionDOMElement.style['-ms-content-zooming'] = 'none';
@@ -246,6 +247,8 @@ InteractionManager.prototype.removeEvents = function ()
         return;
     }
 
+    core.ticker.shared.remove(this._tick);
+
     if (window.navigator.msPointerEnabled)
     {
         this.interactionDOMElement.style['-ms-content-zooming'] = '';
@@ -268,15 +271,15 @@ InteractionManager.prototype.removeEvents = function ()
 };
 
 /**
- * updates the state of interactive objects
- *
- * @private
+ * Updates the state of interactive objects.
+ * Invoked by a throttled ticker update from
+ * {@link PIXI.ticker.shared}.
  */
 InteractionManager.prototype.update = function ()
 {
-    this.requestId = requestAnimationFrame(this.updateBound);
+    this._deltaTime = 0;
 
-    if( this.throttleUpdate() || !this.interactionDOMElement)
+    if (!this.interactionDOMElement)
     {
         return;
     }
@@ -290,7 +293,7 @@ InteractionManager.prototype.update = function ()
 
     this.cursor = 'inherit';
 
-    this.processInteractive(this.mouse.global, this.renderer._lastObjectRendered , this.processMouseOverOut.bind(this) , true );
+    this.processInteractive(this.mouse.global, this.renderer._lastObjectRendered, this.processMouseOverOut, true );
 
     if (this.currentCursorStyle !== this.cursor)
     {
@@ -322,29 +325,6 @@ InteractionManager.prototype.dispatchEvent = function ( displayObject, eventStri
             displayObject[eventString]( eventData );
         }
     }
-};
-
-/**
- * Ensures the interaction checks don't happen too often by delaying the update loop
- *
- * @private
- */
-InteractionManager.prototype.throttleUpdate = function ()
-{
-    // frequency of 30fps??
-    var now = Date.now();
-    var diff = now - this.last;
-
-    diff = (diff * this.interactionFrequency ) / 1000;
-
-    if (diff < 1)
-    {
-        return true;
-    }
-
-    this.last = now;
-
-    return false;
 };
 
 /**
@@ -488,7 +468,7 @@ InteractionManager.prototype.onMouseUp = function (event)
     this.mouse.originalEvent = event;
     this.eventData.data = this.mouse;
     this.eventData.stopped = false;
-    
+
     // Update internal mouse reference
     this.mapPositionToPoint( this.mouse.global, event.clientX, event.clientY);
 
@@ -865,10 +845,6 @@ InteractionManager.prototype.destroy = function () {
     this.processTouchMove = null;
 
     this._tempPoint = null;
-
-    cancelAnimationFrame(this.requestId);
-
-    this.updateBound = null;
 };
 
 core.WebGLRenderer.registerPlugin('interaction', InteractionManager);

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -168,23 +168,6 @@ InteractionManager.prototype.constructor = InteractionManager;
 module.exports = InteractionManager;
 
 /**
- * Ensures the interaction checks don't happen too often by delaying the update loop
- *
- * @private
- */
-InteractionManager.prototype._tick = function (deltaTime)
-{
-    this._deltaTime += deltaTime;
-
-    if (this._deltaTime < this.interactionFrequency)
-    {
-        return;
-    }
-
-    this.update();
-};
-
-/**
  * Sets the DOM element which will receive mouse/touch events. This is useful for when you have
  * other DOM elements on top of the renderers Canvas element. With this you'll be bale to deletegate
  * another DOM element to receive those events.
@@ -215,7 +198,7 @@ InteractionManager.prototype.addEvents = function ()
         return;
     }
 
-    core.ticker.shared.add(this._tick, this);
+    core.ticker.shared.add(this.update, this);
 
     if (window.navigator.msPointerEnabled)
     {
@@ -247,7 +230,7 @@ InteractionManager.prototype.removeEvents = function ()
         return;
     }
 
-    core.ticker.shared.remove(this._tick);
+    core.ticker.shared.remove(this.update);
 
     if (window.navigator.msPointerEnabled)
     {
@@ -274,9 +257,18 @@ InteractionManager.prototype.removeEvents = function ()
  * Updates the state of interactive objects.
  * Invoked by a throttled ticker update from
  * {@link PIXI.ticker.shared}.
+ *
+ * @param deltaTime {number}
  */
-InteractionManager.prototype.update = function ()
+InteractionManager.prototype.update = function (deltaTime)
 {
+    this._deltaTime += deltaTime;
+
+    if (this._deltaTime < this.interactionFrequency)
+    {
+        return;
+    }
+
     this._deltaTime = 0;
 
     if (!this.interactionDOMElement)

--- a/src/polyfill/requestAnimationFrame.js
+++ b/src/polyfill/requestAnimationFrame.js
@@ -54,7 +54,7 @@ if (!global.requestAnimationFrame) {
 
         return setTimeout(function () {
             lastTime = Date.now();
-            callback(global.performance.now());
+            callback(performance.now());
         }, delay);
     };
 }

--- a/src/ticker/Ticker.js
+++ b/src/ticker/Ticker.js
@@ -90,6 +90,14 @@ function Ticker()
     this.deltaTime = 1;
 
     /**
+     * The time elapsed in milliseconds
+     * from current frame since the last frame.
+     *
+     * @member {number}
+     */
+    this.elapsedMS = 0;
+
+    /**
      * The last time {@link PIXI.ticker.Ticker#update}
      * was invoked by animation frame callback or manually.
      *
@@ -296,19 +304,17 @@ Ticker.prototype.stop = function stop()
  */
 Ticker.prototype.update = function update(currentTime)
 {
-    var elapsedMS;
-
     // Allow calling update directly with default currentTime.
     currentTime = currentTime || performance.now();
-    elapsedMS = currentTime - this.lastTime;
+    this.elapsedMS = currentTime - this.lastTime;
 
     // cap the milliseconds elapsed
-    if (elapsedMS > this._maxElapsedMS)
+    if (this.elapsedMS > this._maxElapsedMS)
     {
-        elapsedMS = this._maxElapsedMS;
+        this.elapsedMS = this._maxElapsedMS;
     }
 
-    this.deltaTime = (elapsedMS * core.TARGET_FPMS);
+    this.deltaTime = (this.elapsedMS * core.TARGET_FPMS);
     // Factor in speed
     this.deltaTime *= this.speed;
 

--- a/src/ticker/Ticker.js
+++ b/src/ticker/Ticker.js
@@ -25,7 +25,7 @@ function hasListeners(emitter)
  * e.g. When the ticker is started and the emitter has listeners.
  *
  * @class
- * @memberof PIXI.extras
+ * @memberof PIXI.ticker
  */
 function Ticker()
 {
@@ -90,7 +90,7 @@ function Ticker()
     this.deltaTime = 1;
 
     /**
-     * The last time {@link PIXI.extras.Ticker#update}
+     * The last time {@link PIXI.ticker.Ticker#update}
      * was invoked by animation frame callback or manually.
      *
      * @member {number}
@@ -108,8 +108,8 @@ function Ticker()
 
     /**
      * Whether or not this ticker has been started.
-     * `true` if {@link PIXI.extras.Ticker.start} has been called.
-     * `false` if {@link PIXI.extras.Ticker.stop} has been called.
+     * `true` if {@link PIXI.ticker.Ticker.start} has been called.
+     * `false` if {@link PIXI.ticker.Ticker.stop} has been called.
      *
      * @member {boolean}
      */
@@ -122,10 +122,10 @@ Object.defineProperties(Ticker.prototype, {
      * ticker is running. The default is appoximately
      * 60 FPS in modern browsers, but may vary.
      * This also factors in the property value of
-     * {@link PIXI.extras.Ticker#speed}.
+     * {@link PIXI.ticker.Ticker#speed}.
      *
      * @member
-     * @memberof PIXI.extras.Ticker#
+     * @memberof PIXI.ticker.Ticker#
      * @readonly
      */
     FPS: {
@@ -138,10 +138,10 @@ Object.defineProperties(Ticker.prototype, {
     /**
      * This property manages the maximum amount
      * of time allowed to elapse between ticks,
-     * or calls to {@link PIXI.extras.Ticker#update}.
+     * or calls to {@link PIXI.ticker.Ticker#update}.
      *
      * @member
-     * @memberof PIXI.extras.Ticker#
+     * @memberof PIXI.ticker.Ticker#
      * @default 10
      */
     minFPS: {
@@ -216,7 +216,7 @@ Ticker.prototype._startIfPossible = function _startIfPossible()
  * internal 'tick' event. It checks if the emitter has listeners,
  * and if so it requests a new animation frame at this point.
  *
- * @returns {PIXI.extras.Ticker} this
+ * @returns {PIXI.ticker.Ticker} this
  */
 Ticker.prototype.add = function add(fn, context)
 {
@@ -232,7 +232,7 @@ Ticker.prototype.add = function add(fn, context)
  * internal 'tick' event. It checks if the emitter has listeners,
  * and if so it requests a new animation frame at this point.
  *
- * @returns {PIXI.extras.Ticker} this
+ * @returns {PIXI.ticker.Ticker} this
  */
 Ticker.prototype.addOnce = function addOnce(fn, context)
 {
@@ -248,7 +248,7 @@ Ticker.prototype.addOnce = function addOnce(fn, context)
  * It checks if the emitter has listeners for 'tick' event.
  * If it does, then it cancels the animation frame.
  *
- * @returns {PIXI.extras.Ticker} this
+ * @returns {PIXI.ticker.Ticker} this
  */
 Ticker.prototype.remove = function remove(fn, once)
 {
@@ -317,16 +317,5 @@ Ticker.prototype.update = function update(currentTime)
 
     this.lastTime = currentTime;
 };
-
-/**
- * The shared ticker instance used by {@link PIXI.extras.MovieClip}.
- * The property {@link PIXI.extras.Ticker#autoStart} is set to true
- * for this instance.
- *
- * @type {PIXI.extras.Ticker}
- * @memberof PIXI.extras.Ticker
- */
-Ticker.sharedTicker = new Ticker();
-Ticker.sharedTicker.autoStart = true;
 
 module.exports = Ticker;

--- a/src/ticker/index.js
+++ b/src/ticker/index.js
@@ -1,0 +1,24 @@
+/**
+ * @file        Main export of the PIXI extras library
+ * @author      Mat Groves <mat@goodboydigital.com>
+ * @copyright   2013-2015 GoodBoyDigital
+ * @license     {@link https://github.com/GoodBoyDigital/pixi.js/blob/master/LICENSE|MIT License}
+ */
+var Ticker = require('./Ticker');
+
+/**
+ * The shared ticker instance used by {@link PIXI.extras.MovieClip}.
+ * and by {@link PIXI.interaction.InteractionManager}.
+ * The property {@link PIXI.ticker.Ticker#autoStart} is set to true
+ * for this instance.
+ *
+ * @type {PIXI.ticker.Ticker}
+ * @memberof PIXI.ticker
+ */
+var shared = new Ticker();
+shared.autoStart = true;
+
+module.exports = {
+    shared: shared,
+    Ticker: Ticker
+};


### PR DESCRIPTION
These additional Ticker refactor changes include:
- Separate update() from requesting an animation frame
    - This allows calling update() with a completely separate animation/ticking API if necessary or one chooses
- Complete all TODOs (documentation and more)
    - Added const.TARGET_FPMS
    - Added readonly property ticker.FPS
    - Added readwrite property ticker.minFPS
- added polyfilled "performance" to jshint globals
    - removed `global` in usages of it