### PR TITLE
movieclip loop fix

### DIFF
--- a/src/extras/MovieClip.js
+++ b/src/extras/MovieClip.js
@@ -71,6 +71,8 @@ function MovieClip(textures)
      * @readonly
      */
     this.playing = false;
+
+    this.update = this.update.bind(this);
 }
 
 // constructor


### PR DESCRIPTION
When one MovieClip has loop property set to false and ended its animation - it stops correctly but it also stops every other MovieClip on stage even those that have loop set to true. The playing property stays with true value but the update call has been cancelled.

```javascript
createExplosion(explosionTextures,true,100,100);
setTimeout(function(){
		createExplosion(explosionTextures,false,400,100);
}, 2000);

function createExplosion(textures,loop,_x,_y){

	var explosion = new PIXI.MovieClip(textures);
	explosion.loop = loop;
	explosion.test = true;
				
	explosion.position.x = _x;
	explosion.position.y = _y;
	explosion.anchor.x = 0.5;
	explosion.anchor.y = 0.5;
				
	explosion.rotation = Math.random() * Math.PI;
	explosion.scale.x = explosion.scale.y = 0.75 + Math.random() * 0.5
				
	explosion.gotoAndPlay(0);
				
	stage.addChild(explosion);
}
```