### PR TITLE
EventEmitter3 version1.0.0F, Ticker fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "brfs": "^1.4.0",
-    "eventemitter3": "^0.1.6",
+    "eventemitter3": "^1.0.0",
     "object-assign": "^2.0.0",
     "pixi-spine": "^1.0.1",
     "resource-loader": "^1.4.0"

--- a/src/ticker/Ticker.js
+++ b/src/ticker/Ticker.js
@@ -9,12 +9,14 @@ var core = require('../core'),
  * does a bit too much for what this is for.
  * This is simple enough to keep track of and contribute
  * back to the eventemitter3 project in the near future.
+ * Note: No need to check for specific event because the
+ * composed emitter only uses a single event.
  *
  * @private
  */
 function hasListeners(emitter)
 {
-    return !!(emitter._events && emitter._events[TICK]);
+    return !!emitter._events;
 }
 
 /**
@@ -46,14 +48,13 @@ function Ticker()
 
         if (_this.started)
         {
+            // Invoke listeners now
             _this.update(time);
-        }
-        // Check here because listeners could have side effects
-        // and may have modified state during frame execution.
-        // A new frame may have been requested or listeners removed.
-        if (_this.started && _this._requestId === null && hasListeners(_this._emitter))
-        {
-            _this._requestId = requestAnimationFrame(_this._tick);
+            // Listener side effects may have modified ticker state.
+            if (_this.started && _this._requestId === null && hasListeners(_this._emitter))
+            {
+                _this._requestId = requestAnimationFrame(_this._tick);
+            }
         }
     };
     /**

--- a/src/ticker/index.js
+++ b/src/ticker/index.js
@@ -30,7 +30,7 @@ var Ticker = require('./Ticker');
  *     var stage = new PIXI.Container();
  *     var interactionManager = PIXI.interaction.InteractionManager(renderer);
  *     document.body.appendChild(renderer.view);
- *     ticker.add(function () {
+ *     ticker.add(function (time) {
  *         renderer.render(stage);
  *     });
  *
@@ -38,12 +38,12 @@ var Ticker = require('./Ticker');
  *     // Or you can just update it manually.
  *     ticker.autoStart = false;
  *     ticker.stop();
- *     function animate() {
+ *     function animate(time) {
  *         ticker.update(time);
  *         renderer.render(stage);
  *         requestAnimationFrame(animate);
  *     }
- *     animate();
+ *     animate(performance.now());
  *
  * @type {PIXI.ticker.Ticker}
  * @memberof PIXI.ticker


### PR DESCRIPTION
@englercj I'm assuming this should coincide with a resource-loader update, but getting it in here now.

Would like to give another shout out to @3rd-Eden for the enhancements, thank you!

Changes:
- move _tick check inside first started condition
- minor documentation updates
- removes the private api access on the composed emitter
- pass context in remove method
- update package.json to eventemitter3 1.0.0