### PR TITLE
SmartBlurFilter to use delta as uniform rather than const

### DIFF
--- a/src/filters/blur/SmartBlurFilter.js
+++ b/src/filters/blur/SmartBlurFilter.js
@@ -18,7 +18,7 @@ function SmartBlurFilter()
         fs.readFileSync(__dirname + '/smartBlur.frag', 'utf8'),
         // uniforms
         {
-          delta: { type: 'v2', value: { x: 0.1, y: 0.1 } }
+          delta: { type: 'v2', value: { x: 0.1, y: 0.0 } }
         }
     );
 }

--- a/src/filters/blur/SmartBlurFilter.js
+++ b/src/filters/blur/SmartBlurFilter.js
@@ -15,7 +15,11 @@ function SmartBlurFilter()
         // vertex shader
         null,
         // fragment shader
-        fs.readFileSync(__dirname + '/smartBlur.frag', 'utf8')
+        fs.readFileSync(__dirname + '/smartBlur.frag', 'utf8'),
+        // uniforms
+        {
+          delta: { type: 'v2', value: { x: 0.1, y: 0.1 } }
+        }
     );
 }
 

--- a/src/filters/blur/smartBlur.frag
+++ b/src/filters/blur/smartBlur.frag
@@ -3,7 +3,7 @@ precision mediump float;
 varying vec2 vTextureCoord;
 
 uniform sampler2D uSampler;
-const vec2 delta = vec2(1.0/10.0, 0.0);
+uniform vec2 delta;
 
 float random(vec3 scale, float seed)
 {


### PR DESCRIPTION
Hey there !
I was toying with the SmartBlur filter and I noticed the delta param was used as a const in the fragment shader and I think it should rather be a uniform as you can end up with interesting results playing with this variable. What do you guys think ?
Thanks for the great work, I can't wait for the release of V3 :)