### PR TITLE
Allow access to resource by its name

### DIFF
--- a/src/loaders/textureParser.js
+++ b/src/loaders/textureParser.js
@@ -9,7 +9,7 @@ module.exports = function ()
         {
             resource.texture = new core.Texture(new core.BaseTexture(resource.data, null, core.utils.getResolutionOfUrl(resource.url)));
             // lets also add the frame to pixi's global cache for fromFrame and fromImage fucntions
-            core.utils.TextureCache[resource.url] = resource.texture;
+            core.utils.TextureCache[resource.name] = resource.texture;
         }
 
         next();


### PR DESCRIPTION
Since ResourceLoader [is giving `resource.url` as a `resource.name` if none is given](https://github.com/englercj/resource-loader/blob/master/src/Loader.js#L212), I think it should be allowed to call a texture by it's name. I came across this use case, where only the Loader is aware of paths and it became tricky to give each objects its textures root path.