### PR TITLE
[v3] Canvas resolution fix

### DIFF
--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -480,8 +480,8 @@ Sprite.prototype._renderCanvas = function (renderer)
                 0,
                 width * resolution * renderer.resolution,
                 height * resolution * renderer.resolution,
-                dx / resolution,
-                dy / resolution,
+                dx,
+                dy,
                 width * renderer.resolution,
                 height * renderer.resolution
             );
@@ -494,8 +494,8 @@ Sprite.prototype._renderCanvas = function (renderer)
                 texture.crop.y * resolution,
                 width * resolution * renderer.resolution,
                 height * resolution * renderer.resolution,
-                dx / resolution,
-                dy / resolution,
+                dx,
+                dy,
                 width * renderer.resolution,
                 height * renderer.resolution
             );


### PR DESCRIPTION
We are using resolution prefixes in a little different way then only for retina displays. We use 0.5 resolution of textures in mobile version and 1 for desktop while renderer resolution is always one. It allows us to use smaller textures on mobile to make low-end devices handle it.
It works fine for WebGL renderer, but in canvas sprites positions were completely wrong.
This change fixes it.