### PR TITLE
Small inconsistency between Text and BitmapText

### DIFF
--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -191,8 +191,12 @@ Object.defineProperties(BitmapText.prototype, {
         },
         set: function (value)
         {
+            value = value.toString() || ' ';
+            if (this._text === value)
+            {
+                return;
+            }
             this._text = value;
-
             this.dirty = true;
         }
     }


### PR DESCRIPTION
Setting a text now use toString(), like PIXI.Text.
Atm, creating a BitmapText from a number fails silently.

Note : first PR ever, so if I did something wrong, let me know.