### PR TITLE
Fix touch datas for cocoonjs default configuration

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -779,6 +779,12 @@ InteractionManager.prototype.getTouchData = function (touchEvent)
     touchData.identifier = touchEvent.identifier;
     this.mapPositionToPoint( touchData.global, touchEvent.clientX, touchEvent.clientY );
 
+    if(navigator.isCocoonJS)
+    {
+        touchData.global.x = touchData.global.x / this.resolution;
+        touchData.global.y = touchData.global.y / this.resolution;
+    }
+
     touchEvent.globalX = touchData.global.x;
     touchEvent.globalY = touchData.global.y;
 


### PR DESCRIPTION
When CocoonJS use a scale mode (default), global.x and global.y need to be divided by
the resolution of the interaction manager.

If you specify "no scale", it won't work properly. However, there is to my knowledge no way to detect the scale mode of CocoonJS and by default it is set to "ScaleToFill".

I believe that the default conf should work with PIXI.

Furthermore, CocoonJS defines "No scale" as a "Do it yourself" mode.