### PR TITLE
Fix in InteractionManager

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -352,6 +352,11 @@ InteractionManager.prototype.processInteractive = function (point, displayObject
     }
 
     var children = displayObject.children;
+    
+    // the object could be destroyed before this is called, so check if children exist 
+    if (!children) {
+        return false;
+    }
 
     var hit = false;
 


### PR DESCRIPTION
A display object can be destroyed before
InteractionManager.prototype.processInteractive is called, resulting in
an error because there’s no check if children still exist.