### PR TITLE
Simple support for using large or unbounded sets of textures over time

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,7 @@ module.exports = function(grunt) {
             '<%= dirs.src %>/extras/PIXISpine.js',
             '<%= dirs.src %>/textures/BaseTexture.js',
             '<%= dirs.src %>/textures/Texture.js',
+            '<%= dirs.src %>/textures/TextureCacheManager.js',
             '<%= dirs.src %>/textures/RenderTexture.js',
             '<%= dirs.src %>/textures/VideoTexture.js',
             '<%= dirs.src %>/loaders/AssetLoader.js',

--- a/src/pixi/loaders/ImageLoader.js
+++ b/src/pixi/loaders/ImageLoader.js
@@ -48,7 +48,7 @@ PIXI.ImageLoader.prototype.load = function()
 {
     if(!this.texture.baseTexture.hasLoaded)
     {
-        this.texture.baseTexture.on('loaded', this.onLoaded.bind(this));
+        this.texture.baseTexture.once('loaded', this.onLoaded.bind(this));
     }
     else
     {

--- a/src/pixi/textures/BaseTexture.js
+++ b/src/pixi/textures/BaseTexture.js
@@ -6,6 +6,8 @@ PIXI.BaseTextureCache = {};
 
 PIXI.BaseTextureCacheIdGenerator = 0;
 
+PIXI.BaseTextureCacheManager = null;
+
 /**
  * A texture stores the information that represents an image. All textures have a base texture.
  *
@@ -248,7 +250,12 @@ PIXI.BaseTexture.prototype.unloadFromGPU = function()
  */
 PIXI.BaseTexture.fromImage = function(imageUrl, crossorigin, scaleMode)
 {
-    var baseTexture = PIXI.BaseTextureCache[imageUrl];
+    if (!PIXI.BaseTextureCacheManager)
+    {
+        PIXI.BaseTextureCacheManager = new PIXI.CumulativeCacheManager(PIXI.BaseTextureCache);
+    }
+
+    var baseTexture = PIXI.BaseTextureCacheManager.get(imageUrl);
 
     if(crossorigin === undefined && imageUrl.indexOf('data:') === -1) crossorigin = true;
 
@@ -265,7 +272,7 @@ PIXI.BaseTexture.fromImage = function(imageUrl, crossorigin, scaleMode)
         image.src = imageUrl;
         baseTexture = new PIXI.BaseTexture(image, scaleMode);
         baseTexture.imageUrl = imageUrl;
-        PIXI.BaseTextureCache[imageUrl] = baseTexture;
+        PIXI.BaseTextureCacheManager.put(imageUrl, baseTexture);
 
         // if there is an @2x at the end of the url we are going to assume its a highres image
         if( imageUrl.indexOf(PIXI.RETINA_PREFIX + '.') !== -1)

--- a/src/pixi/textures/TextureCacheManager.js
+++ b/src/pixi/textures/TextureCacheManager.js
@@ -1,0 +1,92 @@
+/**
+ * @author Andrew Champion http://aschampion.github.io/
+ */
+
+/**
+ * @class CumulativeCacheManager
+ * @constructor
+ */
+PIXI.CumulativeCacheManager = function (cache) {
+    this.cache = cache;
+};
+
+PIXI.CumulativeCacheManager.prototype.constructor = PIXI.CumulativeCacheManager;
+
+PIXI.CumulativeCacheManager.prototype.put = function (key, value) {
+    this.cache[key] = value;
+};
+
+PIXI.CumulativeCacheManager.prototype.get = function (key) {
+    return this.cache[key];
+};
+
+PIXI.CumulativeCacheManager.prototype.touch = function () {};
+
+PIXI.LRUCacheManager = function (cache, capacity) {
+    this.cache = cache;
+    this.capacity = capacity;
+    this.size = 0;
+    this.queue = {};
+    this.oldest = null;
+    this.newest = null;
+};
+
+PIXI.LRUCacheManager.prototype.constructor = PIXI.LRUCacheManager;
+
+PIXI.LRUCacheManager.prototype.put = function (key, value) {
+    while (this.size > this.capacity && this.oldest !== null) {
+        this.remove(this.oldest);
+    }
+    this.cache[key] = value;
+    this.touch(key);
+};
+
+PIXI.LRUCacheManager.prototype.get = function (key) {
+    var value = this.cache[key];
+
+    if (typeof value !== 'undefined') {
+        this.touch(key);
+    }
+
+    return value;
+};
+
+PIXI.LRUCacheManager.prototype.touch = function (key) {
+    var status = this.queue[key];
+
+    if (typeof status !== 'undefined') { // Key is already tracked by cache.
+        if (status.newer !== null) this.queue[status.newer].older = status.older;
+        if (status.older !== null) this.queue[status.older].newer = status.newer;
+        if (this.oldest === key) this.oldest = status.newer;
+    } else {
+        this.size++;
+    }
+
+    this.queue[key] = {newer: null, older: this.newest};
+    if (this.newest !== null && this.newest !== key) {
+        this.queue[this.newest].newer = key;
+    }
+    this.newest = key;
+    if (this.oldest === null) {
+        this.oldest = key;
+    }
+};
+
+PIXI.LRUCacheManager.prototype.remove = function (key) {
+    var status = this.queue[key];
+
+    if (typeof status !== 'undefined') { // Key is already tracked by cache.
+        if (status.newer !== null) this.queue[status.newer].older = status.older;
+        if (status.older !== null) this.queue[status.older].newer = status.newer;
+        if (this.oldest === key) this.oldest = status.newer;
+        if (this.newest === key) this.newest = status.older;
+        this.size--;
+    }
+    delete this.queue[key];
+
+    var value = this.cache[key];
+    if (typeof value.destroy === 'function') {
+        value.destroy();
+    }
+    delete this.cache[key];
+};

--- a/src/pixi/textures/TextureCacheManager.js
+++ b/src/pixi/textures/TextureCacheManager.js
@@ -3,8 +3,13 @@
  */
 
 /**
+ * A cumulative cache stores all items put into it indefinitely, unless the
+ * underlying cache object is manually cleared. If the set of items that will
+ * be cached is large or unbounded, consider using PIXI.LRUCacheManager instead.
+ *
  * @class CumulativeCacheManager
  * @constructor
+ * @param cache {Object} The backing object that will store references to cached items.
  */
 PIXI.CumulativeCacheManager = function (cache) {
     this.cache = cache;
@@ -22,6 +27,17 @@ PIXI.CumulativeCacheManager.prototype.get = function (key) {
 
 PIXI.CumulativeCacheManager.prototype.touch = function () {};
 
+/**
+ * A least recently used (LRU) cache stores all items put into it until it has
+ * reached capacity, at which point newly inserted items will remove least
+ * recently used items from the cache. This manager is only aware of uses which
+ * call its touch method.
+ *
+ * @class LRUCacheManager
+ * @constructor
+ * @param cache {Object} The backing object that will store references to cached items.
+ * @param capacity {Number} The maximum number of items that should be cached.
+ */
 PIXI.LRUCacheManager = function (cache, capacity) {
     this.cache = cache;
     this.capacity = capacity;


### PR DESCRIPTION
This PR fixes two issues when loading a large number of textures over time. For example, our use case is browsing massive image stacks of microscopy data, so while the size of textures in use at any given time is reasonable, a browsing session over several hours may cover dozens of GB of image data.

1. The `ImageLoader` for each texture is retained, which can accumulate memory and crash the browser.
2. The default texture caching strategy is cumulative, which while appropriate for games with a known, in-memory limit on the total number of textures required, does not fit our use case. Again this results in an OOM browser crash.

The current implementation solving 2, creating a LRU cache manager wrapping `BaseTextureCache`, is a bit rough, but I wanted to gauge interest in merging before cleaning it up since it meets our needs as is.