### PR TITLE
updates text before calling getLocalBounds

### DIFF
--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -344,13 +344,34 @@ BitmapText.prototype.updateText = function ()
  */
 BitmapText.prototype.updateTransform = function ()
 {
+    this.validate();
+    this.containerUpdateTransform();
+};
+
+/**
+ * Validates text before calling parent's getLocalBounds
+ *
+ * @return {Rectangle} The rectangular bounding area
+ */
+
+BitmapText.prototype.getLocalBounds = function()
+{
+    this.validate();
+    return core.Container.prototype.getLocalBounds.call(this);
+};
+
+/**
+ * Updates text when needed
+ *
+ * @private
+ */
+BitmapText.prototype.validate = function()
+{
     if (this.dirty)
     {
         this.updateText();
         this.dirty = false;
     }
-
-    this.containerUpdateTransform();
 };
 
 BitmapText.fonts = {};


### PR DESCRIPTION
when text has been changed properties width/height had wrong value, to fix it we need to update text first and then calculate local bounds