### PR TITLE
Fixed MovieClip when using negative animationSpeed

### DIFF
--- a/src/extras/MovieClip.js
+++ b/src/extras/MovieClip.js
@@ -200,8 +200,7 @@ MovieClip.prototype.update = function (deltaTime)
     {
         if (this.loop)
         {
-            this._currentTime += this._textures.length;
-            this._texture = this._textures[this._currentTime];
+            this._texture = this._textures[this._textures.length - 1 + floor % this._textures.length];
         }
         else
         {


### PR DESCRIPTION
If you initially set the animationSpeed to a negative value (to play the animation backwards), the current implementation fails. This PR fixes this issue.