### PR TITLE
Make Canvas Renderer functional again.

### DIFF
--- a/src/core/renderers/canvas/utils/CanvasGraphics.js
+++ b/src/core/renderers/canvas/utils/CanvasGraphics.js
@@ -7,6 +7,7 @@ var CONST = require('../../../const');
  * @memberof PIXI
  */
 var CanvasGraphics ={};
+module.exports = CanvasGraphics;
 
 /*
  * Renders a Graphics object to a canvas.
@@ -299,7 +300,7 @@ CanvasGraphics.renderGraphicsMask = function (graphics, context)
  *
  * @private
  * @param graphics {Graphics} the graphics that will have its tint updated
- * 
+ *
  */
 CanvasGraphics.updateGraphicsTint = function (graphics)
 {
@@ -347,4 +348,3 @@ CanvasGraphics.updateGraphicsTint = function (graphics)
 
     }
 };
-

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -490,12 +490,12 @@ Sprite.prototype._renderCanvas = function (renderer)
         {
             renderer.context.drawImage(
                 texture.baseTexture.source,
-                texture.crop.x * resolution,
-                texture.crop.y * resolution,
+                texture.crop.x * resolution * renderer.resolution,
+                texture.crop.y * resolution * renderer.resolution,
                 width * resolution * renderer.resolution,
                 height * resolution * renderer.resolution,
-                dx,
-                dy,
+                dx * renderer.resolution,
+                dy * renderer.resolution,
                 width * renderer.resolution,
                 height * renderer.resolution
             );


### PR DESCRIPTION
- fix sprite texture square (#1778)
- fix missing export in CanvasGraphics (#1790)