### PR TITLE
Fix TilingSprite tilePosition + tileScale bug

### DIFF
--- a/src/extras/TilingSprite.js
+++ b/src/extras/TilingSprite.js
@@ -197,8 +197,8 @@ TilingSprite.prototype._renderWebGL = function (renderer)
     this.shader.uniforms.uFrame.value[2] = tempUvs.x1 - tempUvs.x0;
     this.shader.uniforms.uFrame.value[3] = tempUvs.y2 - tempUvs.y0;
 
-    this.shader.uniforms.uTransform.value[0] = (this.tilePosition.x % tempWidth) / this._width;
-    this.shader.uniforms.uTransform.value[1] = (this.tilePosition.y % tempHeight) / this._height;
+    this.shader.uniforms.uTransform.value[0] = (this.tilePosition.x % (tempWidth * this.tileScale.x)) / this._width;
+    this.shader.uniforms.uTransform.value[1] = (this.tilePosition.y % (tempHeight * this.tileScale.y)) / this._height;
     this.shader.uniforms.uTransform.value[2] = ( tw / this._width ) * this.tileScale.x;
     this.shader.uniforms.uTransform.value[3] = ( th / this._height ) * this.tileScale.y;
 
@@ -229,8 +229,8 @@ TilingSprite.prototype._renderCanvas = function (renderer)
         transform = this.worldTransform,
         resolution = renderer.resolution,
         baseTexture = texture.baseTexture,
-        modX = this.tilePosition.x % texture._frame.width,
-        modY = this.tilePosition.y % texture._frame.height;
+        modX = this.tilePosition.x % (texture._frame.width * this.tileScale.x),
+        modY = this.tilePosition.y % (texture._frame.height * this.tileScale.y);
 
     // create a nice shiny pattern!
     // TODO this needs to be refreshed if texture changes..


### PR DESCRIPTION
Demonstration: http://www.davidsweetman.com/pixi/demo/

When the tilePosition was set to be greater than the texture
width while a tileScale was applied, taking the tilePosition
modulo the texture width would cause the resulting texture
coordinates to drift off of whole steps of the texture.

This fix takes the tileScale into account while applying the
tilePosition.