### PR TITLE
Only call Container.removeChildren if there are children

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -563,7 +563,11 @@ Container.prototype.destroy = function (destroyChildren)
         }
     }
 
-    this.removeChildren();
+    // Since this is called by Sprite.destroy and sprites don't have children double check to see if there are children first
+    if (this.children)
+    {
+        this.removeChildren();
 
-    this.children = null;
+        this.children = null;
+    }
 };


### PR DESCRIPTION
This fixes an error when calling `Sprite.destroy` as per #1813.