### PR TITLE
Fix wrong scaleMode passing in generateTexture

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -296,7 +296,7 @@ Container.prototype.generateTexture = function (renderer, resolution, scaleMode)
 {
     var bounds = this.getLocalBounds();
 
-    var renderTexture = new RenderTexture(renderer, bounds.width | 0, bounds.height | 0, renderer, scaleMode, resolution);
+    var renderTexture = new RenderTexture(renderer, bounds.width | 0, bounds.height | 0, scaleMode, resolution);
 
     _tempMatrix.tx = -bounds.x;
     _tempMatrix.ty = -bounds.y;


### PR DESCRIPTION
renderer where passed instead of scaleMode parameter. causing wrong scaleMode on textures.