### PR TITLE
Add convenience event 'clicktap' that combines events for 'click' and 'tap'

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -488,7 +488,12 @@ InteractionManager.prototype.processMouseUp = function ( displayObject, hit )
         if( displayObject[ isDown ] )
         {
             displayObject[ isDown ] = false;
-            this.dispatchEvent( displayObject, isRightButton ? 'rightclick' : 'click', this.eventData );
+            if (isRightButton) {
+                this.dispatchEvent( displayObject, 'rightclick', this.eventData );
+            } else {
+                this.dispatchEvent( displayObject, 'click', this.eventData );
+                this.dispatchEvent( displayObject, 'clicktap', this.eventData );
+            }
         }
     }
     else
@@ -702,6 +707,7 @@ InteractionManager.prototype.processTouchEnd = function ( displayObject, hit )
         {
             displayObject._touchDown = false;
             this.dispatchEvent( displayObject, 'tap', this.eventData );
+            this.dispatchEvent( displayObject, 'clicktap', this.eventData );
         }
     }
     else


### PR DESCRIPTION
Disclaimer: I'm not sure this is the best way of doing it.

In our code we have a few places where we do
```javascript
container.once("click", doSomething);
container.once("tap", doSomething);
```

This PR adds a new event called "clicktap" that combines the two:
```javascript
container.once("clicktap", doSomething);
```

I've run testem (some of the tests timed out), ~~but I couldn't figure out how to run jshint~~ (It's ```gulp jshint```). The CONTRIBUTING.md is a bit out-of-date, so I apologise if I missed a step.