### PR TITLE
Fix tilingsprite from a spritesheet

### DIFF
--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -221,9 +221,9 @@ SpriteRenderer.prototype.render = function (sprite)
 
     var w0, w1, h0, h1;
 
-    if (texture.trim)
+    if (texture.trim && sprite.tileScale === undefined)
     {
-        // if the sprite is trimmed then we need to add the extra space before transforming the sprite coords..
+        // if the sprite is trimmed and is not a tilingsprite then we need to add the extra space before transforming the sprite coords..
         var trim = texture.trim;
 
         w1 = trim.x - aX * trim.width;

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -346,7 +346,7 @@ InteractionManager.prototype.mapPositionToPoint = function ( point, x, y )
  */
 InteractionManager.prototype.processInteractive = function (point, displayObject, func, hitTest, interactive )
 {
-    if(!displayObject.visible)
+    if(displayObject === undefined || !displayObject.visible)
     {
         return false;
     }

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -346,7 +346,7 @@ InteractionManager.prototype.mapPositionToPoint = function ( point, x, y )
  */
 InteractionManager.prototype.processInteractive = function (point, displayObject, func, hitTest, interactive )
 {
-    if(displayObject === undefined || !displayObject.visible)
+    if(!displayObject.visible)
     {
         return false;
     }


### PR DESCRIPTION
Fix https://github.com/GoodBoyDigital/pixi.js/issues/1787

When rendering a tilingsprite, we should use the frame and not the trimmed texture.

Thanks @greewi for this one.

I used tileScale to determine if the sprite is a tilingsprite. Tell me if you know a better way.