### PR TITLE
Define package files, up devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "test": "gulp && testem ci",
     "docs": "jsdoc -c ./gulp/util/jsdoc.conf.json -R README.md"
   },
+  "files": [
+    "bin/",
+    "src/"
+  ],
   "dependencies": {
     "async": "^0.9.0",
     "brfs": "^1.4.0",
@@ -28,16 +32,16 @@
     "resource-loader": "^1.6.0"
   },
   "devDependencies": {
-    "browserify": "^9.0.8",
-    "chai": "^2.2.0",
-    "del": "^1.1.1",
+    "browserify": "^10.2.1",
+    "chai": "^2.3.0",
+    "del": "^1.2.0",
     "gulp": "^3.8.11",
-    "gulp-cached": "^1.0.4",
+    "gulp-cached": "^1.1.0",
     "gulp-concat": "^2.5.2",
     "gulp-debug": "^2.0.1",
     "gulp-jshint": "^1.10.0",
     "gulp-mirror": "^0.4.0",
-    "gulp-plumber": "^1.0.0",
+    "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.2.0",
@@ -46,13 +50,13 @@
     "jsdoc": "^3.3.0-beta3",
     "jshint-summary": "^0.4.0",
     "minimist": "^1.1.1",
-    "mocha": "^2.2.4",
+    "mocha": "^2.2.5",
     "require-dir": "^0.3.0",
-    "run-sequence": "^1.0.2",
-    "testem": "^0.8.2",
+    "run-sequence": "^1.1.0",
+    "testem": "^0.8.3",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
-    "watchify": "^3.1.2"
+    "watchify": "^3.2.1"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
@englercj instead of commenting yet again here https://github.com/GoodBoyDigital/pixi.js/issues/1832

I just made a PR :wink: 

This defines just 2 dirs in files `bin/` and `src/`.
`package.json`, `README.md`, and `LICENSE` are included by default.

Run the following to ensure:
```sh
npm pack
```

Also updated dev dependencies. Again like last time, browserify was a major update, tested new bin with examples repo everything seems a ok, also testem still passes. Build is just slightly faster :rocket: 