### PR TITLE
Improved Particle Shader performance by discarding transparent pixels

### DIFF
--- a/src/core/particles/webgl/ParticleShader.js
+++ b/src/core/particles/webgl/ParticleShader.js
@@ -49,7 +49,9 @@ function ParticleShader(shaderManager)
             'uniform float uAlpha;',
 
             'void main(void){',
-            '   gl_FragColor = texture2D(uSampler, vTextureCoord) * vColor * uAlpha ;',
+            '  vec4 color = texture2D(uSampler, vTextureCoord) * vColor * uAlpha;',
+            '  if (color.a == 0.0) discard;',
+            '  gl_FragColor = color;',
             '}'
         ].join('\n'),
         // custom uniforms


### PR DESCRIPTION
On my machine the impact was a 50% fps boost on the bunnymark with 50,000 bunnies:
-Before: 30fps
-After: 45fps

The Improvement makes sense considering that roughly 30% of the pixels of the bunny texture are transparent and the bottleneck is blending the fragments together.

I do not know about other hardware but on my machine I still get 30fps while using completely opaque textures. Meaning that executing ```if (color.a == 0.0) discard;``` has no measurable performance impact and could be added to other fragment shaders.