### PR TITLE
Trigger "added" and "removed" events when adding children on Container

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -131,7 +131,7 @@ Container.prototype.addChildAt = function (child, index)
 
         this.children.splice(index, 0, child);
 
-        child.emit('added');
+        child.emit('added', this);
 
         return child;
     }
@@ -250,7 +250,7 @@ Container.prototype.removeChildAt = function (index)
     child.parent = null;
     this.children.splice(index, 1);
 
-    child.emit('removed');
+    child.emit('removed', this);
 
     return child;
 };

--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -130,6 +130,9 @@ Container.prototype.addChildAt = function (child, index)
         child.parent = this;
 
         this.children.splice(index, 0, child);
+
+        child.emit('added');
+
         return child;
     }
     else
@@ -246,6 +249,8 @@ Container.prototype.removeChildAt = function (index)
 
     child.parent = null;
     this.children.splice(index, 1);
+
+    child.emit('removed');
 
     return child;
 };

--- a/test/unit/core/display/Container.test.js
+++ b/test/unit/core/display/Container.test.js
@@ -18,15 +18,16 @@ describe('PIXI.Container', function () {
                 triggeredAdded = false,
                 triggeredRemoved = false;
 
-            child.on('added', function() {
+            child.on('added', function(to) {
                 triggeredAdded = true;
                 expect(container.children.length).to.be.equals(1);
-                expect(child.parent).to.be.equals(container);
+                expect(child.parent).to.be.equals(to);
             });
-            child.on('removed', function() {
+            child.on('removed', function(from) {
                 triggeredRemoved = true;
                 expect(container.children.length).to.be.equals(0);
                 expect(child.parent).to.be.null();
+                expect(container).to.be.equals(from);
             });
 
             container.addChild(child);

--- a/test/unit/core/display/Container.test.js
+++ b/test/unit/core/display/Container.test.js
@@ -1,0 +1,41 @@
+describe('PIXI.Container', function () {
+    describe('parent', function () {
+        it('should be present when adding children to Container', function() {
+            var container = new PIXI.Container(),
+                child = new PIXI.DisplayObject();
+
+            expect(container.children.length).to.be.equals(0);
+            container.addChild(child);
+            expect(container.children.length).to.be.equals(1);
+            expect(child.parent).to.be.equals(container);
+        });
+    });
+
+    describe('events', function () {
+        it('should trigger "added" and "removed" events on it\'s children', function () {
+            var container = new PIXI.Container(),
+                child = new PIXI.DisplayObject(),
+                triggeredAdded = false,
+                triggeredRemoved = false;
+
+            child.on('added', function() {
+                triggeredAdded = true;
+                expect(container.children.length).to.be.equals(1);
+                expect(child.parent).to.be.equals(container);
+            });
+            child.on('removed', function() {
+                triggeredRemoved = true;
+                expect(container.children.length).to.be.equals(0);
+                expect(child.parent).to.be.null();
+            });
+
+            container.addChild(child);
+            expect(triggeredAdded).to.be.true();
+            expect(triggeredRemoved).to.be.false();
+
+            container.removeChild(child);
+            expect(triggeredRemoved).to.be.true();
+        });
+
+    });
+});


### PR DESCRIPTION
Hello there,

This is similar to Flash's `Event.ADDED_TO_STAGE` behavior.
I've added a simple test for that. 

**Usage example:**

```javascript
class Something extends PIXI.Container {

  constructor () 
  {
    super();

    this.on('added', this.onAdded, this);
    this.on('removed', this.onRemoved, this);
  }

  onAdded (to) 
  {
    console.log("I'm now attached to some Container!", to)
  }

  onRemoved (from) 
  {
    console.log("I was removed from the Container. :(", from)
  }

}
```