### PR TITLE
Update CONTRIBUTING guide.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,8 @@ the library, steps to reproduce, etc. "X isn't working!!!1!" will probably just 
 
 ## Making Changes
 
-To setup for making changes you will need node.js, and grunt installed. You can download node.js
-from [nodejs.org][3]. After it has been installed open a console and run `npm i -g grunt-cli` to
-install the global `grunt` executable.
+To setup for making changes you will need node.js. You can download node.js from
+[nodejs.org][3].
 
 After that you can clone the pixi.js repository, and run `npm i` inside the cloned folder.
 This will install dependencies necessary for building the project. Once that is ready, make your
@@ -36,10 +35,10 @@ changes and submit a Pull Request. When submitting a PR follow these guidlines:
 `master` is the latest release and PRs to that branch will be closed.
 
 - **Ensure changes are jshint validated.** After making a change be sure to run the build process
-to ensure that you didn't break anything. You can do this with `grunt && grunt test` which will run
+to ensure that you didn't break anything. You can do this with `npm test` which will run
 jshint, rebuild, then run the test suite.
 
-- **Never commit new builds.** When making a code change, you should always run `grunt` which will
+- **Never commit new builds.** When making a code change, you should always run `npm run build` which will
 rebuild the project, *however* please do not commit these new builds or your PR will be closed.
 
 - **Only commit relevant changes.** Don't include changes that are not directly relevant to the fix

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "test": "gulp && testem ci",
+    "build": "gulp",
     "docs": "jsdoc -c ./gulp/util/jsdoc.conf.json -R README.md"
   },
   "files": [


### PR DESCRIPTION
- Removed `grunt` references
- Avoid `gulp` on the guide, since `npm run build` now can do the same.

If there is a need to replace gulp with something else in the future, there is no need to change it in the contributing guide. :)