### PR TITLE
dispatch mousemove/touchmove event only inside hit area

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -540,7 +540,10 @@ InteractionManager.prototype.onMouseMove = function (event)
  */
 InteractionManager.prototype.processMouseMove = function ( displayObject, hit )
 {
-    this.dispatchEvent( displayObject, 'mousemove', this.eventData);
+    if(hit)
+    {
+        this.dispatchEvent( displayObject, 'mousemove', this.eventData);
+    }
     this.processMouseOverOut(displayObject, hit);
 };
 
@@ -756,8 +759,10 @@ InteractionManager.prototype.onTouchMove = function (event)
  */
 InteractionManager.prototype.processTouchMove = function ( displayObject, hit )
 {
-    hit = hit;
-    this.dispatchEvent( displayObject, 'touchmove', this.eventData);
+    if (hit)
+    {
+        this.dispatchEvent( displayObject, 'touchmove', this.eventData);
+    }
 };
 
 /**


### PR DESCRIPTION
Fixes #1837 and #1884

Live example with the patch: https://jsfiddle.net/endel/upz3t2a0/1/