### PR TITLE
[Fix/Hack] Displacement filter blurry on iphone4, iphone4s and ipod5

### DIFF
--- a/src/filters/displacement/displacement.frag
+++ b/src/filters/displacement/displacement.frag
@@ -17,5 +17,5 @@ void main(void)
    map -= 0.5;
    map.xy *= scale;
 
-   gl_FragColor = texture2D(uSampler, vec2(vTextureCoord.x + map.x, vTextureCoord.y + map.y));
+   gl_FragColor = texture2D(uSampler, vec2(vTextureCoord.x + 0.999 * map.x, vTextureCoord.y + 0.999 * map.y));
 }

--- a/src/filters/displacement/displacement.frag
+++ b/src/filters/displacement/displacement.frag
@@ -1,4 +1,4 @@
-precision lowp float;
+precision mediump float;
 
 varying vec2 vMapCoord;
 varying vec2 vTextureCoord;

--- a/src/filters/displacement/displacement.frag
+++ b/src/filters/displacement/displacement.frag
@@ -17,5 +17,5 @@ void main(void)
    map -= 0.5;
    map.xy *= scale;
 
-   gl_FragColor = texture2D(uSampler, vec2(vTextureCoord.x + 0.999 * map.x, vTextureCoord.y + 0.999 * map.y));
+   gl_FragColor = texture2D(uSampler, vec2(vTextureCoord.x + map.x, vTextureCoord.y + map.y));
 }


### PR DESCRIPTION
Added hack to displacement filter shader to avoid pixelized effect on some devices.
Tested devices that have the issue: iphone4, iphone4s, ipod5, ipad2
Tested devices that do not have the issue: Samsung Galaxy s3/s4, iphone 5s, iphone 6, ipad air

I know this does not look clean in the code but it has the effect of solving a very ugly bug (probably hardware related):

Before the hack:
![bunnies_pixel](https://cloud.githubusercontent.com/assets/1897225/8321000/7057a814-1a5c-11e5-87fa-a2661375084b.PNG)

After the hack:
![bunnies_smooth](https://cloud.githubusercontent.com/assets/1897225/8321001/7297f372-1a5c-11e5-9e1d-352a0662ea59.PNG)

PS: I stole your bunnies for this small demo but be assured that no harm was done to them (beside being exploded into 10 smaller copies of themselves)
