### PR TITLE
Minor readme link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Pixi.js — A 2D JavaScript Renderer
 
 ![pixi.js logo](http://www.goodboydigital.com/pixijs/pixi_v3_github-pad.png)
 
-[![projects](http://www.pixijs.com/wp-content/uploads/2013/05/headerPanel_projects-898x342.jpg)](http://www.pixijs.com/projects)
+[![projects](http://www.pixijs.com/wp-content/uploads/2013/05/headerPanel_projects-898x342.jpg)](http://www.pixijs.com/projects/)
 
 ## Pixi.js ##
 


### PR DESCRIPTION
Add trailing / so wordpress can find projects page.

failure repro:
```
$ time curl -i http://www.pixijs.com/projects
HTTP/1.1 200 OK
Date: Wed, 24 Jun 2015 14:14:16 GMT
Server: Apache
Vary: Accept-Encoding
Transfer-Encoding: chunked
Content-Type: text/html


<br />
<b>Warning</b>:  Cannot modify header information - headers already sent by (output started at /home/voynixserve/pixijs.com/index.php:2) in <b>/home/voynixserve/pixijs.com/wp-includes/pluggable.php</b> on line <b>1121</b><br />

real	0m2.292s
user	0m0.005s
sys	0m0.004s
```

this works
[http://www.pixijs.com/projects/](http://www.pixijs.com/projects/)
but this does not
[http://www.pixijs.com/projects](http://www.pixijs.com/projects)

