### PR TITLE
Ensure that sprite width and height are never negative

### DIFF
--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -112,7 +112,7 @@ Object.defineProperties(Sprite.prototype, {
         },
         set: function (value)
         {
-            this.scale.x = utils.sgn(this.scale.x) * value / this.texture._frame.width;
+            this.scale.x = utils.sign(this.scale.x) * value / this.texture._frame.width;
             this._width = value;
         }
     },
@@ -130,7 +130,7 @@ Object.defineProperties(Sprite.prototype, {
         },
         set: function (value)
         {
-            this.scale.y = utils.sgn(this.scale.y) * value / this.texture._frame.height;
+            this.scale.y = utils.sign(this.scale.y) * value / this.texture._frame.height;
             this._height = value;
         }
     },
@@ -182,12 +182,12 @@ Sprite.prototype._onTextureUpdate = function ()
     // so if _width is 0 then width was not set..
     if (this._width)
     {
-        this.scale.x = utils.sgn(this.scale.x) * this._width / this.texture.frame.width;
+        this.scale.x = utils.sign(this.scale.x) * this._width / this.texture.frame.width;
     }
 
     if (this._height)
     {
-        this.scale.y = utils.sgn(this.scale.y) * this._height / this.texture.frame.height;
+        this.scale.y = utils.sign(this.scale.y) * this._height / this.texture.frame.height;
     }
 };
 

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -108,11 +108,11 @@ Object.defineProperties(Sprite.prototype, {
     width: {
         get: function ()
         {
-            return this.scale.x * this.texture._frame.width;
+            return Math.abs(this.scale.x) * this.texture._frame.width;
         },
         set: function (value)
         {
-            this.scale.x = value / this.texture._frame.width;
+            this.scale.x = utils.sgn(this.scale.x) * value / this.texture._frame.width;
             this._width = value;
         }
     },
@@ -126,11 +126,11 @@ Object.defineProperties(Sprite.prototype, {
     height: {
         get: function ()
         {
-            return  this.scale.y * this.texture._frame.height;
+            return  Math.abs(this.scale.y) * this.texture._frame.height;
         },
         set: function (value)
         {
-            this.scale.y = value / this.texture._frame.height;
+            this.scale.y = utils.sgn(this.scale.y) * value / this.texture._frame.height;
             this._height = value;
         }
     },
@@ -182,12 +182,12 @@ Sprite.prototype._onTextureUpdate = function ()
     // so if _width is 0 then width was not set..
     if (this._width)
     {
-        this.scale.x = this._width / this.texture.frame.width;
+        this.scale.x = utils.sgn(this.scale.x) * this._width / this.texture.frame.width;
     }
 
     if (this._height)
     {
-        this.scale.y = this._height / this.texture.frame.height;
+        this.scale.y = utils.sgn(this.scale.y) * this._height / this.texture.frame.height;
     }
 };
 

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -224,6 +224,16 @@ var utils = module.exports = {
     },
 
     /**
+     * Retunrs sign of number
+     *
+     * @param n {number}
+     * @returns {number} 0 if n is 0, -1 if n is negative, 1 if n i positive
+     */
+    sgn: function (n){
+        return n === 0 ? 0 : n < 0 ? -1 : 1;
+    },
+
+    /**
      * @todo Describe property usage
      * @private
      */

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -229,8 +229,8 @@ var utils = module.exports = {
      * @param n {number}
      * @returns {number} 0 if n is 0, -1 if n is negative, 1 if n i positive
      */
-    sgn: function (n){
-        return n === 0 ? 0 : n < 0 ? -1 : 1;
+    sign: function (n) {
+        return n ? (n < 0 ? -1 : 1) : 0;
     },
 
     /**

--- a/test/unit/core/sprites/Sprite.test.js
+++ b/test/unit/core/sprites/Sprite.test.js
@@ -1,0 +1,55 @@
+describe('PIXI.Sprite', function () {
+    describe('width', function () {
+        it('should not be negative for nagative scale.x', function () {
+            var sprite = new PIXI.Sprite();
+
+            sprite.width = 100;
+            expect(sprite.width).to.be.at.least(0);
+            sprite.scale.x = -1;
+            expect(sprite.width).to.be.at.least(0);
+        });
+
+        it('should not change sign of scale.x', function () {
+            var texture = new PIXI.Texture(new PIXI.BaseTexture());
+            var sprite = new PIXI.Sprite();
+
+            texture.width = 100;
+            sprite.scale.x = 1;
+            sprite.width = 50;
+
+            expect(sprite.scale.x).to.be.above(0);
+
+            sprite.scale.x = -1;
+            sprite.width = 75;
+
+            expect(sprite.scale.x).to.be.below(0);
+        });
+    });
+
+    describe('height', function () {
+        it('should not be negative for nagative scale.y', function () {
+            var sprite = new PIXI.Sprite();
+
+            sprite.height = 100;
+            expect(sprite.height).to.be.at.least(0);
+            sprite.scale.y = -1;
+            expect(sprite.height).to.be.at.least(0);
+        });
+
+        it('should not change sign of scale.y', function () {
+            var texture = new PIXI.Texture(new PIXI.BaseTexture());
+            var sprite = new PIXI.Sprite();
+
+            texture.height = 100;
+            sprite.scale.y = 1;
+            sprite.height = 50;
+
+            expect(sprite.scale.y).to.be.above(0);
+
+            sprite.scale.y = -1;
+            sprite.height = 75;
+
+            expect(sprite.scale.y).to.be.below(0);
+        });
+    });
+});

--- a/test/unit/core/utils/util.test.js
+++ b/test/unit/core/utils/util.test.js
@@ -86,4 +86,25 @@ describe('PIXI.utils', function () {
                 .to.be.a('function');
         });
     });
+
+    describe('.sgn', function () {
+        it('should return 0 for 0', function () {
+            expect(PIXI.utils.sgn(0))
+                .to.be.equal(0);
+        });
+
+        it('should return -1 for negative numbers', function () {
+            for (var i = 0;i<10;i+=1){
+                expect(PIXI.utils.sgn(-Math.random()))
+                    .to.be.equal(-1);
+            }
+        });
+
+        it('should return 1 for positive numbers', function () {
+            for (var i = 0;i<10;i+=1){
+                expect(PIXI.utils.sgn(Math.random() + 0.000001))
+                    .to.be.equal(1);
+            }
+        });
+    });
 });

--- a/test/unit/core/utils/util.test.js
+++ b/test/unit/core/utils/util.test.js
@@ -87,22 +87,22 @@ describe('PIXI.utils', function () {
         });
     });
 
-    describe('.sgn', function () {
+    describe('.sign', function () {
         it('should return 0 for 0', function () {
-            expect(PIXI.utils.sgn(0))
+            expect(PIXI.utils.sign(0))
                 .to.be.equal(0);
         });
 
         it('should return -1 for negative numbers', function () {
             for (var i = 0;i<10;i+=1){
-                expect(PIXI.utils.sgn(-Math.random()))
+                expect(PIXI.utils.sign(-Math.random()))
                     .to.be.equal(-1);
             }
         });
 
         it('should return 1 for positive numbers', function () {
             for (var i = 0;i<10;i+=1){
-                expect(PIXI.utils.sgn(Math.random() + 0.000001))
+                expect(PIXI.utils.sign(Math.random() + 0.000001))
                     .to.be.equal(1);
             }
         });


### PR DESCRIPTION
I found out that sprite.width is negative when sprite.x is negative (same for height and scale.y). Here's a fix for that, and some tests.

This is the same change as in my previous PR - https://github.com/GoodBoyDigital/pixi.js/pull/1942, but my previous was to wrong branch, contained built files etc.