### PR TITLE
CavasRendered.roundPixels can now be set from options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ npm-debug.log
 node_modules
 docs/
 examples_old/
+
+# jetBrains IDE ignores
+.idea

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -21,6 +21,7 @@ var SystemRenderer = require('../SystemRenderer'),
  * @param [options.resolution=1] {number} the resolution of the renderer retina would be 2
  * @param [options.clearBeforeRender=true] {boolean} This sets if the CanvasRenderer will clear the canvas or
  *      not before the new render pass.
+ * @param [options.roundPixels=false] {boolean} If true Pixi will Math.floor() x/y values when rendering, stopping pixel interpolation.
  */
 function CanvasRenderer(width, height, options)
 {
@@ -55,7 +56,7 @@ function CanvasRenderer(width, height, options)
      *
      * @member {boolean}
      */
-    this.roundPixels = false;
+    this.roundPixels = options.roundPixels === true;
 
     /**
      * Tracks the active scale mode for this renderer.
@@ -219,7 +220,7 @@ CanvasRenderer.prototype.resize = function (w, h)
     //reset the scale mode.. oddly this seems to be reset when the canvas is resized.
     //surely a browser bug?? Let pixi fix that for you..
     this.currentScaleMode = CONST.SCALE_MODES.DEFAULT;
-    
+
     if(this.smoothProperty)
     {
         this.context[this.smoothProperty] = (this.currentScaleMode === CONST.SCALE_MODES.LINEAR);


### PR DESCRIPTION
https://github.com/GoodBoyDigital/pixi.js/issues/1936#issuecomment-118040768

Beside seting roundPixels from options I also added ```.idea``` to ```.gitignore``` - please tell if I shall revert this change, or create another PR for this. I use webstorm, and having ```idea``` in pixi's ```.gitignore``` would be handy for potential future PR.


This is the same change as in my previous https://github.com/GoodBoyDigital/pixi.js/pull/1940, but my previous was to wrong branch, contained built files etc.