### PR TITLE
Fixed canvas renderer options undefined error

### DIFF
--- a/src/core/const.js
+++ b/src/core/const.js
@@ -189,7 +189,8 @@ var CONST = {
         transparent: false,
         backgroundColor: 0x000000,
         clearBeforeRender: true,
-        preserveDrawingBuffer: false
+        preserveDrawingBuffer: false,
+        roundPixels: false
     },
 
     /**

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -25,6 +25,8 @@ var SystemRenderer = require('../SystemRenderer'),
  */
 function CanvasRenderer(width, height, options)
 {
+    options = options || {};
+
     SystemRenderer.call(this, 'Canvas', width, height, options);
 
     this.type = CONST.RENDERER_TYPE.CANVAS;
@@ -56,7 +58,7 @@ function CanvasRenderer(width, height, options)
      *
      * @member {boolean}
      */
-    this.roundPixels = options.roundPixels === true;
+    this.roundPixels = options.roundPixels;
 
     /**
      * Tracks the active scale mode for this renderer.


### PR DESCRIPTION
Fixed an undefined error that would happen in the canvas renderer if no options were passed into the constructor. Also added roundPixels to the default render options.