### PR TITLE
Add documentation: SystemRenderer.backgroundColor

### DIFF
--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -145,6 +145,12 @@ function SystemRenderer(system, width, height, options)
      */
     this._backgroundColorString = '#000000';
 
+    /**
+     * The background color as a number.
+     *
+     * @member {number}
+     * @default 0x000000
+     */
     this.backgroundColor = options.backgroundColor || this._backgroundColor; // run bg color setter
 
     /**


### PR DESCRIPTION
As in #1777, noticed this isn't documented in the public docs since only the private field has been commented.