### PR TITLE
Added a 'PIXI' namespace in jsdocs to reveal this property in the documentation

### DIFF
--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -168,7 +168,7 @@ Object.defineProperties(SystemRenderer.prototype, {
      * The background color to fill if not transparent
      *
      * @member {number}
-     * @memberof SystemRenderer#
+     * @memberof PIXI.SystemRenderer#
      */
     backgroundColor:
     {


### PR DESCRIPTION
Currently there is a lack of documentation for this property.